### PR TITLE
Entity생성

### DIFF
--- a/src/main/java/com/example/sesacrunback/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/sesacrunback/domain/cart/entity/CartItem.java
@@ -1,5 +1,36 @@
 package com.example.sesacrunback.domain.cart.entity;
 
-public class CartItem {
+import com.example.sesacrunback.domain.course.course.entity.Course;
+import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.global.common.entity.BaseCreateEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "cart_items")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem extends BaseCreateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+
+    @ManyToOne
+    @JoinColumn(name = "user_id",nullable = false)
+    private User user; // 장바구니 주인
+
+    @ManyToOne
+    @JoinColumn(name = "course_id",nullable = false)
+    private Course course; // 장바구니에 담은 강의
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/chat/chat/entity/Chat.java
+++ b/src/main/java/com/example/sesacrunback/domain/chat/chat/entity/Chat.java
@@ -1,5 +1,33 @@
 package com.example.sesacrunback.domain.chat.chat.entity;
 
-public class Chat {
+import com.example.sesacrunback.domain.chat.message.entity.ChatMessage;
+import com.example.sesacrunback.global.common.entity.BaseCreateEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "chat")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chat extends BaseCreateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String name; // 채팅방 이름
+
+    @OneToMany(mappedBy = "chat", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>(); // 채팅 메시지 목록
 }

--- a/src/main/java/com/example/sesacrunback/domain/chat/message/entity/ChatMessage.java
+++ b/src/main/java/com/example/sesacrunback/domain/chat/message/entity/ChatMessage.java
@@ -1,5 +1,44 @@
 package com.example.sesacrunback.domain.chat.message.entity;
 
-public class ChatMessage {
+import com.example.sesacrunback.domain.chat.chat.entity.Chat;
+import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.global.common.entity.BaseCreateEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "chat_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseCreateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String content; // 메시지 내용
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MessageType type; // 메시지 타입 (일반, 시스템)
+
+    @ManyToOne
+    @JoinColumn(name = "chat_id", nullable = false)
+    private Chat chat; // 소속된 채팅방
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender; // 발신자
 }

--- a/src/main/java/com/example/sesacrunback/domain/chat/message/entity/MessageType.java
+++ b/src/main/java/com/example/sesacrunback/domain/chat/message/entity/MessageType.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.chat.message.entity;
+
+public enum MessageType {
+    TEXT,    // 일반 메시지
+    SYSTEM   // 시스템 메시지
+}

--- a/src/main/java/com/example/sesacrunback/domain/course/course/entity/Course.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/entity/Course.java
@@ -1,5 +1,81 @@
 package com.example.sesacrunback.domain.course.course.entity;
 
-public class Course {
+import com.example.sesacrunback.domain.course.section.entity.Section;
+import com.example.sesacrunback.domain.orderItem.entity.OrderItem;
+import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "courses")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Course extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String title; // 강의 제목
+
+    @Column(nullable = false)
+    private String description; // 강의 설명 (짧은)
+
+    private String detailedDescription; // 강의 상세 설명
+
+    @Column(nullable = false)
+    private String thumbnail; // 썸네일 이미지 URL
+
+
+    @Column(nullable = false)
+    private  String category; // 카테고리
+
+    @Column(nullable = false)
+    private Integer price; // 판매가
+
+    private Integer originalPrice; // 정가 (할인 전 가격)
+
+    @Column(nullable = false)
+    private String level; // 난이도
+
+    @Column(nullable = false)
+    private String language; // 사용 언어
+
+    @Column(nullable = false)
+    private String duration; // 총 강의 시간
+
+    @Column(nullable = false)
+    private Integer studentCount; // 수강생 수
+
+    @Column(nullable = false)
+    private LocalDate lastUpdated; // 마지막 업데이트 일자
+
+    private LocalDateTime deletedAt; // 삭제일시 (Soft Delete)
+
+    @ManyToOne
+    @JoinColumn(name = "instructor_id",nullable = false)
+    private User instructor; // 강의자
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Section> sections = new ArrayList<>(); // 강의에 포함된 섹션 목록
+
+    @OneToMany(mappedBy = "course")
+    private List<OrderItem> orderItems = new ArrayList<>(); // 이 강의를 포함하는 주문 항목 목록
 }

--- a/src/main/java/com/example/sesacrunback/domain/course/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/lecture/entity/Lecture.java
@@ -1,5 +1,46 @@
 package com.example.sesacrunback.domain.course.lecture.entity;
 
-public class Lecture {
+import com.example.sesacrunback.domain.course.section.entity.Section;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "lectures")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Lecture extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String title; // 강의 제목
+
+    @Column(nullable = false)
+    private String youtubeUrl; // 유튜브 URL
+
+    @Column(nullable = false)
+    private String duration; // 강의 시간
+
+    @Column(nullable = false)
+    private Boolean isFree; // 무료 여부
+
+    @Column(nullable = false)
+    private Integer orderIndex; // 순서
+
+    @ManyToOne
+    @JoinColumn(name = "section_id", nullable = false)
+    private Section section; // 소속된 섹션
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/course/section/entity/Section.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/section/entity/Section.java
@@ -1,5 +1,44 @@
 package com.example.sesacrunback.domain.course.section.entity;
 
-public class Section {
+import com.example.sesacrunback.domain.course.course.entity.Course;
+import com.example.sesacrunback.domain.course.lecture.entity.Lecture;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "sections")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Section extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String title; // 섹션 제목
+
+    @Column(nullable = false)
+    private Integer orderIndex; // 순서
+
+    @ManyToOne
+    @JoinColumn(name = "course_id" , nullable = false)
+    private Course course; // 소속된 강의
+
+    @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Lecture> lectures = new ArrayList<>(); // 섹션에 포함된 강의 목록
 }

--- a/src/main/java/com/example/sesacrunback/domain/order/entity/Order.java
+++ b/src/main/java/com/example/sesacrunback/domain/order/entity/Order.java
@@ -1,5 +1,55 @@
 package com.example.sesacrunback.domain.order.entity;
 
-public class Order {
+import com.example.sesacrunback.domain.orderItem.entity.OrderItem;
+import com.example.sesacrunback.domain.payment.entity.Payment;
+import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String orderNumber; // 주문 번호
+
+    @Column(nullable = false)
+    private int totalAmount; // 총 주문 금액
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderState status; // 주문 상태
+
+
+    @ManyToOne
+    @JoinColumn(name = "user_id",nullable = false)
+    private User user; // 주문한 사용자
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>(); // 주문에 포함된 항목 목록
+
+    @OneToOne(mappedBy = "order")
+    private Payment payment; // 주문에 대한 결제 정보
 }

--- a/src/main/java/com/example/sesacrunback/domain/order/entity/OrderState.java
+++ b/src/main/java/com/example/sesacrunback/domain/order/entity/OrderState.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.order.entity;
+
+public enum OrderState {
+    ORDER,
+    REFUND,
+}

--- a/src/main/java/com/example/sesacrunback/domain/orderItem/entity/OrderItem.java
+++ b/src/main/java/com/example/sesacrunback/domain/orderItem/entity/OrderItem.java
@@ -1,5 +1,40 @@
 package com.example.sesacrunback.domain.orderItem.entity;
 
-public class OrderItem {
+import com.example.sesacrunback.domain.course.course.entity.Course;
+import com.example.sesacrunback.domain.order.entity.Order;
+import com.example.sesacrunback.global.common.entity.BaseCreateEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "order_items")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem extends BaseCreateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String courseName; // 주문 당시의 강의 이름 (기록용)
+
+    @Column(nullable = false)
+    private  int price; // 주문 당시의 가격 (기록용)
+
+    @ManyToOne
+    @JoinColumn(name = "order_id",nullable = false)
+    private Order order; // 소속된 주문
+
+    @ManyToOne
+    @JoinColumn(name = "course_id",nullable = false)
+    private Course course; // 주문한 강의
 }

--- a/src/main/java/com/example/sesacrunback/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/sesacrunback/domain/payment/entity/Payment.java
@@ -1,5 +1,51 @@
 package com.example.sesacrunback.domain.payment.entity;
 
-public class Payment {
+import com.example.sesacrunback.domain.order.entity.Order;
+import com.example.sesacrunback.domain.refund.entity.Refund;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "payments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false, unique = true)
+    private String portonePaymentId; // 포트원 결제 ID
+
+    @Column(nullable = false)
+    private int amount; // 결제 금액
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status; // 결제 상태
+
+    private String portoneData; // 포트원 결제 데이터 (JSON)
+
+    @OneToOne
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order; // 관련된 주문
+
+    @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL)
+    private List<Refund> refunds = new ArrayList<>(); // 이 결제와 관련된 환불 목록
 }

--- a/src/main/java/com/example/sesacrunback/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/example/sesacrunback/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.payment.entity;
+
+public enum PaymentStatus {
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/MemberRole.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/MemberRole.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.recruitment.member.entity;
+
+public enum MemberRole {
+    ORGANIZER,   // 모집자
+    PARTICIPANT  // 참여자
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/MemberStatus.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/MemberStatus.java
@@ -1,0 +1,7 @@
+package com.example.sesacrunback.domain.recruitment.member.entity;
+
+public enum MemberStatus {
+    PENDING,   // 대기중
+    APPROVED,  // 승인됨
+    REJECTED   // 거절됨
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
@@ -1,5 +1,44 @@
 package com.example.sesacrunback.domain.recruitment.member.entity;
 
-public class RecruitmentMember {
+import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
+import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "recruitment_members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecruitmentMember extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role; // 역할 (모집자, 참여자)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberStatus status; // 상태 (대기중, 승인됨, 거절됨)
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private RecruitmentPost post; // 참여한 모집글
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 참여한 사용자
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentCategory.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentCategory.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.recruitment.post.entity;
+
+public enum RecruitmentCategory {
+    STUDY,    // 스터디
+    PROJECT   // 팀 프로젝트
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
@@ -1,5 +1,67 @@
 package com.example.sesacrunback.domain.recruitment.post.entity;
 
-public class RecruitmentPost {
+import com.example.sesacrunback.domain.recruitment.member.entity.RecruitmentMember;
+import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "recruitment_posts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecruitmentPost extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RecruitmentCategory category; // 카테고리 (스터디, 프로젝트)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RecruitmentStatus status; // 모집 상태 (모집중, 모집완료)
+
+    @Column(nullable = false)
+    private String title; // 제목
+
+    @Column(nullable = false)
+    private String content; // 내용
+
+    @Column(nullable = false)
+    private Integer currentMembers; // 현재 인원
+
+    @Column(nullable = false)
+    private Integer totalMembers; // 총 모집 인원
+
+    @Column(nullable = false)
+    private Integer views; // 조회수
+
+    private LocalDateTime deletedAt; // 삭제일시 (Soft Delete)
+
+    @ManyToOne
+    @JoinColumn(name = "author_id",nullable = false)
+    private User author; // 작성자
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecruitmentMember> recruitmentMembers = new ArrayList<>(); // 이 모집글에 참여한 멤버 목록
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentStatus.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentStatus.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.recruitment.post.entity;
+
+public enum RecruitmentStatus {
+    RECRUITING,// 모집중
+    COMPLETED// 모집완료
+}

--- a/src/main/java/com/example/sesacrunback/domain/refund/entity/Refund.java
+++ b/src/main/java/com/example/sesacrunback/domain/refund/entity/Refund.java
@@ -1,5 +1,43 @@
 package com.example.sesacrunback.domain.refund.entity;
 
-public class Refund {
+import com.example.sesacrunback.domain.payment.entity.Payment;
+import com.example.sesacrunback.global.common.entity.BaseCreateEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@Table(name = "refunds")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Refund extends BaseCreateEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String refundId; // 포트원 환불 ID
+
+    @Column(nullable = false)
+    private int refundAmount; // 환불 금액
+
+    private String reason; // 환불 사유
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RefundStatus status; // 환불 상태
+
+    @ManyToOne
+    @JoinColumn(name = "payment_id",nullable = false)
+    private Payment payment; // 관련된 원 결제
 }

--- a/src/main/java/com/example/sesacrunback/domain/refund/entity/RefundStatus.java
+++ b/src/main/java/com/example/sesacrunback/domain/refund/entity/RefundStatus.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.refund.entity;
+
+public enum RefundStatus {
+    COMPLETED,
+    FAILED,
+}

--- a/src/main/java/com/example/sesacrunback/domain/user/entity/User.java
+++ b/src/main/java/com/example/sesacrunback/domain/user/entity/User.java
@@ -1,5 +1,73 @@
 package com.example.sesacrunback.domain.user.entity;
 
-public class User {
+import com.example.sesacrunback.domain.cart.entity.CartItem;
+import com.example.sesacrunback.domain.chat.message.entity.ChatMessage;
+import com.example.sesacrunback.domain.course.course.entity.Course;
+import com.example.sesacrunback.domain.order.entity.Order;
+import com.example.sesacrunback.domain.recruitment.member.entity.RecruitmentMember;
+import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
+import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false, unique = true)
+    @Email
+    private String email; // 이메일 (로그인 ID)
+
+    @Column(nullable = false)
+    private String password; // 비밀번호
+
+    @Column(nullable = false)
+    private String name; // 이름
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role; // 역할 (일반 사용자, 강의자)
+
+
+    private LocalDateTime deletedAt; // 삭제일시 (Soft Delete)
+
+    @OneToMany(mappedBy = "instructor")
+    private List<Course> createdCourses = new ArrayList<>(); // 이 사용자가 생성한 강의 목록
+
+    @OneToMany(mappedBy = "author")
+    private List<RecruitmentPost> createdRecruitmentPosts = new ArrayList<>(); // 이 사용자가 작성한 모집글 목록
+
+    @OneToMany(mappedBy = "user")
+    private List<Order> orders = new ArrayList<>(); // 이 사용자의 주문 목록
+
+    @OneToMany(mappedBy = "sender")
+    private List<ChatMessage> sentChatMessages = new ArrayList<>(); // 이 사용자가 보낸 채팅 메시지 목록
+
+    @OneToMany(mappedBy = "user")
+    private List<RecruitmentMember> recruitmentMemberships = new ArrayList<>(); // 이 사용자가 참여한 모집 그룹 목록
+
+    @OneToMany(mappedBy = "user")
+    private List<CartItem> cartItems = new ArrayList<>(); // 이 사용자의 장바구니 항목 목록
+
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/user/entity/UserRole.java
+++ b/src/main/java/com/example/sesacrunback/domain/user/entity/UserRole.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.user.entity;
+
+public enum UserRole {
+    USER,
+    INSTRUCTOR
+}

--- a/src/main/java/com/example/sesacrunback/global/common/entity/BaseCreateEntity.java
+++ b/src/main/java/com/example/sesacrunback/global/common/entity/BaseCreateEntity.java
@@ -1,0 +1,17 @@
+package com.example.sesacrunback.global.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseCreateEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/sesacrunback/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/sesacrunback/global/common/entity/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package com.example.sesacrunback.global.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity extends BaseCreateEntity {
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/sesacrunback/global/common/entity/ExClass.java
+++ b/src/main/java/com/example/sesacrunback/global/common/entity/ExClass.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.global.common.entity;
-
-public class ExClass {
-
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,28 @@
+spring:
+  application:
+    name: sesacrun-back
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+
+
+  # ????? ???? ?? ?? ? ?? ??
+  sql:
+    init:
+      mode: always
+
+
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    show-sql: true
+    defer-datasource-initialization: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,58 @@
+-- Users
+INSERT INTO users (email, password, name, role, created_at, updated_at) VALUES
+('instructor@test.com', 'password123', '김강사', 'INSTRUCTOR', NOW(), NOW()),
+('user1@test.com', 'password123', '이학생', 'USER', NOW(), NOW()),
+('user2@test.com', 'password123', '박학생', 'USER', NOW(), NOW());
+
+-- Courses
+INSERT INTO courses (title, description, detailed_description, thumbnail, category, price, original_price, level, language, duration, student_count, last_updated, instructor_id, created_at, updated_at) VALUES
+('자바 완전 정복', '자바 기초부터 심화까지', '자바의 모든 것을 다룹니다.', 'https://example.com/java.png', 'Development', 50000, 70000, 'BEGINNER', 'Java', '10h 30m', 0, CURDATE(), 1, NOW(), NOW()),
+('스프링 부트 입문', '웹 개발의 시작 스프링 부트', '스프링 부트로 웹 서버를 만들어봅니다.', 'https://example.com/spring.png', 'Web', 60000, 80000, 'INTERMEDIATE', 'Java', '15h 00m', 0, CURDATE(), 1, NOW(), NOW());
+
+-- Sections
+INSERT INTO sections (title, order_index, course_id, created_at, updated_at) VALUES
+('자바 기초', 1, 1, NOW(), NOW()),
+('객체 지향 프로그래밍', 2, 1, NOW(), NOW()),
+('스프링 환경설정', 1, 2, NOW(), NOW());
+
+-- Lectures
+INSERT INTO lectures (title, youtube_url, duration, is_free, order_index, section_id, created_at, updated_at) VALUES
+('변수와 자료형', 'https://youtu.be/example1', '10:00', true, 1, 1, NOW(), NOW()),
+('연산자', 'https://youtu.be/example2', '15:00', false, 2, 1, NOW(), NOW()),
+('클래스와 객체', 'https://youtu.be/example3', '20:00', false, 1, 2, NOW(), NOW()),
+('스프링 프로젝트 생성', 'https://youtu.be/example4', '12:00', true, 1, 3, NOW(), NOW());
+
+-- Recruitment Posts
+INSERT INTO recruitment_posts (category, status, title, content, current_members, total_members, views, author_id, created_at, updated_at) VALUES
+('STUDY', 'RECRUITING', '자바 스터디 하실 분', '매주 토요일 자바 공부하실 분 구합니다.', 1, 4, 0, 2, NOW(), NOW()),
+('PROJECT', 'RECRUITING', '스프링 프로젝트 팀원 모집', '쇼핑몰 만드실 분', 1, 4, 10, 3, NOW(), NOW());
+
+-- Recruitment Members
+INSERT INTO recruitment_members (role, status, post_id, user_id, created_at, updated_at) VALUES
+('ORGANIZER', 'APPROVED', 1, 2, NOW(), NOW()),
+('PARTICIPANT', 'APPROVED', 1, 3, NOW(), NOW());
+
+-- Chat
+INSERT INTO chat (name, created_at) VALUES
+('자바 스터디 채팅방', NOW());
+
+-- Chat Messages
+INSERT INTO chat_messages (content, type, chat_id, sender_id, created_at) VALUES
+('안녕하세요 스터디 참여하고 싶습니다.', 'TEXT', 1, 3, NOW()),
+('네 환영합니다!', 'TEXT', 1, 2, NOW());
+
+-- Orders
+INSERT INTO orders (order_number, total_amount, status, user_id, created_at, updated_at) VALUES
+('ORD-20231222-0001', 50000, 'ORDER', 2, NOW(), NOW());
+
+-- Order Items
+INSERT INTO order_items (course_name, price, order_id, course_id, created_at) VALUES
+('자바 완전 정복', 50000, 1, 1, NOW());
+
+-- Payments
+INSERT INTO payments (portone_payment_id, amount, status, order_id, created_at, updated_at) VALUES
+('imp_1234567890', 50000, 'COMPLETED', 1, NOW(), NOW());
+
+-- Cart Items
+INSERT INTO cart_items (user_id, course_id, created_at) VALUES
+(3, 2, NOW());


### PR DESCRIPTION
## ✨ 변경 사항

- 도메인별 JPA Entity 클래스 및 Enum 정의
- 공통 필드(생성일, 수정일) 관리를 위한 Base Entity 추가
- 초기 데이터 적재를 위한 **data.sql** 추가 및 설정

## 🔍 관련 이슈

- 별도의 이슈를 생성하지 못하고 바로 Branch 작업 진행

## 📌 작업 내용

### **1. Entity 및 Enum 구현**

프로젝트에 필요한 핵심 도메인 Entity와 관련 Enum을 구현했습니다.

- User: 사용자 정보 (Role: USER, INSTRUCTOR, ADMIN)
- Course / Section / Lecture: 강의 관련 계층 구조
- RecruitmentPost / RecruitmentMember: 스터디/프로젝트 모집 게시글 및 멤버
- Chat / ChatMessage: 채팅방 및 메시지
- Order / OrderItem / Payment: 주문 및 결제 정보
- Refund: 환불 정보
- CartItem: 장바구니

### **2. Base Entity 적용**

- BaseTimeEntity
  - created_at, updated_at 자동 관리 (@MappedSuperclass, @EntityListeners 적용)
- BaseCreateEntity
  - created_at 만 필요한 경우를 위한 분리

### **3. 더미 데이터 삽입 (data.sql)**

서버 실행 시 기본적으로 들어갈 테스트 데이터를 작성했습니다.

- 강사/학생 계정
- 강의, 섹션, 수업 예시 데이터
- 모집글, 채팅, 주문, 결제 예시 데이터

### **4. 설정 변경 (application.yml)**

- `ddl-auto: create`: 서버 시작 시 테이블 재생성
- `defer-datasource-initialization: true`: Hibernate가 테이블을 생성한 후 **data.sql**이 실행되도록 설정


## 🧪 테스트 방법

1. pring Boot 애플리케이션을 실행합니다. 
    
2. 서버가 정상적으로 실행되면 콘솔 로그에  및  쿼리가 실행되는지 확인합니다.
    
3. 데이터베이스 툴(MySQL 등)을 통해 테이블이 생성되고 더미 데이터가 들어가 있는지 확인합니다.


## 📎 기타 참고사항

- 현재 ddl-auto: create로 설정되어 있어 서버 재실행 시마다 데이터가 초기화됩니다. 추후 개발 단계에 따라 update 또는 validate로 변경이 필요합니다.
