### PR TITLE
18 모임 기능 구현

### DIFF
--- a/src/main/java/com/example/sesacrunback/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/sesacrunback/domain/cart/service/CartService.java
@@ -6,17 +6,15 @@ import com.example.sesacrunback.domain.cart.entity.CartItem;
 import com.example.sesacrunback.domain.cart.repository.CartRepository;
 import com.example.sesacrunback.domain.course.course.entity.Course;
 import com.example.sesacrunback.domain.course.course.repository.CourseRepository;
-import com.example.sesacrunback.domain.orderItem.repository.OrderItemRepository;
 import com.example.sesacrunback.domain.user.entity.User;
 import com.example.sesacrunback.domain.user.repository.UserRepository;
 import com.example.sesacrunback.global.exception.CustomException;
 import com.example.sesacrunback.global.exception.ErrorCode;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,12 +23,12 @@ public class CartService {
     private final CartRepository cartRepository;
     private final UserRepository userRepository;
     private final CourseRepository courseRepository;
-    private final OrderItemRepository orderItemRepository;
+//    private final OrderItemRepository orderItemRepository;
 
     @Transactional
     public CartResponse create(Long userId, CartCreateRequest req) {
         User user = findUserById(userId);
-       Course course = courseRepository.findById(req.getCourseId()).orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
+       Course course = courseRepository.findById(req.getCourseId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
         cartRepository.findByUserAndCourse(user, course).ifPresent(item -> {
             throw new CustomException(ErrorCode.CART_ITEM_ALREADY_EXISTS);
@@ -71,7 +69,7 @@ public class CartService {
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/controller/ExController.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/controller/ExController.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.recruitment.member.controller;
-
-public class ExController {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/controller/RecruitmentMemberController.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/controller/RecruitmentMemberController.java
@@ -1,12 +1,16 @@
 package com.example.sesacrunback.domain.recruitment.member.controller;
 
+import com.example.sesacrunback.domain.recruitment.member.dto.request.MemberUpdateReqDto;
 import com.example.sesacrunback.domain.recruitment.member.service.RecruitmentMemberService;
 import com.example.sesacrunback.global.common.dto.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +25,13 @@ public class RecruitmentMemberController {
     public ResponseEntity<ApiResponse<Long>> applyToRecruitment(@PathVariable Long postId) {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.success(recruitmentMemberService.applyToRecruitment(postId, 1L)));
+    }
+
+    @PatchMapping("/{memberId}")
+    public ResponseEntity<ApiResponse<String>> updateMemberStatus(@PathVariable Long postId, @PathVariable Long memberId,
+        @Valid @RequestBody MemberUpdateReqDto reqDto) {
+        recruitmentMemberService.updateMemberStatus(postId, memberId, 2L, reqDto);
+        return ResponseEntity.ok(ApiResponse.success("상태 변경에 성공했습니다."));
     }
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/controller/RecruitmentMemberController.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/controller/RecruitmentMemberController.java
@@ -1,0 +1,26 @@
+package com.example.sesacrunback.domain.recruitment.member.controller;
+
+import com.example.sesacrunback.domain.recruitment.member.service.RecruitmentMemberService;
+import com.example.sesacrunback.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/recruitments/{postId}/members")
+@RequiredArgsConstructor
+public class RecruitmentMemberController {
+
+    private final RecruitmentMemberService recruitmentMemberService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> applyToRecruitment(@PathVariable Long postId) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(recruitmentMemberService.applyToRecruitment(postId, 1L)));
+    }
+
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/dto/request/ExReqDto.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/dto/request/ExReqDto.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.recruitment.member.dto.request;
-
-public class ExReqDto {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/dto/request/MemberUpdateReqDto.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/dto/request/MemberUpdateReqDto.java
@@ -1,0 +1,15 @@
+package com.example.sesacrunback.domain.recruitment.member.dto.request;
+
+import com.example.sesacrunback.domain.recruitment.member.entity.MemberStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberUpdateReqDto {
+
+    @NotNull(message = "상태는 필수입니다.")
+    private final MemberStatus status;
+
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
@@ -3,6 +3,8 @@ package com.example.sesacrunback.domain.recruitment.member.entity;
 import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
 import com.example.sesacrunback.domain.user.entity.User;
 import com.example.sesacrunback.global.common.entity.BaseTimeEntity;
+import com.example.sesacrunback.global.exception.CustomException;
+import com.example.sesacrunback.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -53,5 +55,24 @@ public class RecruitmentMember extends BaseTimeEntity { //todo 추후 패키지,
             .post(post)
             .user(user)
             .build();
+    }
+
+    public static RecruitmentMember participant(RecruitmentPost post, User user) {
+        return RecruitmentMember.builder()
+            .role(MemberRole.PARTICIPANT)
+            .status(MemberStatus.PENDING) // 참여자는 대기 상태
+            .post(post)
+            .user(user)
+            .build();
+    }
+
+    public void validateCanApply() {
+        if (status == MemberStatus.PENDING) {
+            throw new CustomException(ErrorCode.ALREADY_APPLIED);
+        }
+
+        if (status == MemberStatus.APPROVED) {
+            throw new CustomException(ErrorCode.ALREADY_RECRUITED_MEMBER);
+        }
     }
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
@@ -75,4 +75,30 @@ public class RecruitmentMember extends BaseTimeEntity { //todo 추후 패키지,
             throw new CustomException(ErrorCode.ALREADY_RECRUITED_MEMBER);
         }
     }
+
+    public boolean isOrganizer() {
+        return role == MemberRole.ORGANIZER;
+    }
+
+    public void approve() {
+        validatePendingStatus();
+
+        status = MemberStatus.APPROVED;
+    }
+
+    public void reject() {
+        validatePendingStatus();
+
+        status = MemberStatus.REJECTED;
+    }
+
+    private void validatePendingStatus() {
+        if (!isPending()) {
+            throw new CustomException(ErrorCode.MEMBER_STATUS_NOT_PENDING);
+        }
+    }
+
+    private boolean isPending() {
+        return status == MemberStatus.PENDING;
+    }
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
@@ -46,7 +46,7 @@ public class RecruitmentMember extends BaseTimeEntity { //todo 추후 패키지,
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 참여한 사용자
 
-    public static RecruitmentMember of(RecruitmentPost post, User user) {
+    public static RecruitmentMember organizer(RecruitmentPost post, User user) {
         return RecruitmentMember.builder()
             .role(MemberRole.ORGANIZER)
             .status(MemberStatus.APPROVED) // 모집자는 항상 승인 상태

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
@@ -14,6 +14,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,7 +23,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "recruitment_members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RecruitmentMember extends BaseTimeEntity {
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecruitmentMember extends BaseTimeEntity { //todo 추후 패키지, 엔티티 이름 수정
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // PK
@@ -41,4 +45,13 @@ public class RecruitmentMember extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 참여한 사용자
+
+    public static RecruitmentMember of(RecruitmentPost post, User user) {
+        return RecruitmentMember.builder()
+            .role(MemberRole.ORGANIZER)
+            .status(MemberStatus.APPROVED) // 모집자는 항상 승인 상태
+            .post(post)
+            .user(user)
+            .build();
+    }
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/ExRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/ExRepository.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.recruitment.member.repository;
-
-public interface ExRepository {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/RecruitmentMemberRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/RecruitmentMemberRepository.java
@@ -1,0 +1,13 @@
+package com.example.sesacrunback.domain.recruitment.member.repository;
+
+import com.example.sesacrunback.domain.recruitment.member.entity.RecruitmentMember;
+import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
+import com.example.sesacrunback.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecruitmentMemberRepository extends JpaRepository <RecruitmentMember, Long> {
+
+    boolean existsByPostAndUser(RecruitmentPost post, User user);
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/RecruitmentMemberRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/RecruitmentMemberRepository.java
@@ -13,4 +13,6 @@ public interface RecruitmentMemberRepository extends JpaRepository <RecruitmentM
     boolean existsByPostAndUser(RecruitmentPost post, User user);
 
     Optional<RecruitmentMember> findByPostAndUser(RecruitmentPost post, User user);
+
+    Optional<RecruitmentMember> findTopByPostAndUserOrderByCreatedAtDesc(RecruitmentPost post, User user);
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/RecruitmentMemberRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/repository/RecruitmentMemberRepository.java
@@ -3,6 +3,7 @@ package com.example.sesacrunback.domain.recruitment.member.repository;
 import com.example.sesacrunback.domain.recruitment.member.entity.RecruitmentMember;
 import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
 import com.example.sesacrunback.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface RecruitmentMemberRepository extends JpaRepository <RecruitmentMember, Long> {
 
     boolean existsByPostAndUser(RecruitmentPost post, User user);
+
+    Optional<RecruitmentMember> findByPostAndUser(RecruitmentPost post, User user);
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/ExService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/ExService.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.recruitment.member.service;
-
-public class ExService {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -1,5 +1,7 @@
 package com.example.sesacrunback.domain.recruitment.member.service;
 
+import com.example.sesacrunback.domain.recruitment.member.dto.request.MemberUpdateReqDto;
+import com.example.sesacrunback.domain.recruitment.member.entity.MemberStatus;
 import com.example.sesacrunback.domain.recruitment.member.entity.RecruitmentMember;
 import com.example.sesacrunback.domain.recruitment.member.repository.RecruitmentMemberRepository;
 import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
@@ -45,6 +47,38 @@ public class RecruitmentMemberService {
         return post.getId();
     }
 
+    @Transactional
+    public void updateMemberStatus(Long postId, Long memberId, Long userId, MemberUpdateReqDto reqDto) {
+
+        RecruitmentPost post = getPostById(postId);
+        User user = getUserById(userId);
+
+        // 현재 요청하는 사람이 해당 모임에 참여 중인지
+        RecruitmentMember requester = recruitmentMemberRepository.findByPostAndUser(post, user)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_RECRUITMENT_MEMBER));
+
+        // 모집장이 맞는지
+        if (!requester.isOrganizer()) {
+            throw new CustomException(ErrorCode.NOT_RECRUITMENT_ORGANIZER);
+        }
+
+        RecruitmentMember member = recruitmentMemberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RECRUITED_MEMBER_NOT_FOUND));
+
+        switch (reqDto.getStatus()) {
+            case MemberStatus.APPROVED -> {
+                post.increaseCurrentCount();
+                member.approve();
+            }
+
+            case MemberStatus.REJECTED -> {
+                member.reject();
+            }
+
+            default -> throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+    }
 
     private RecruitmentPost getPostById(Long postId) {
         return recruitmentPostRepository.findById(postId)

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -23,7 +23,7 @@ public class RecruitmentMemberService {
         if (recruitmentMemberRepository.existsByPostAndUser(post, user)) {
             throw new CustomException(ErrorCode.ALREADY_RECRUITED_MEMBER);
         }
-        recruitmentMemberRepository.save(RecruitmentMember.of(post, user));
+        recruitmentMemberRepository.save(RecruitmentMember.organizer(post, user));
     }
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -43,6 +43,9 @@ public class RecruitmentMemberService {
         recruitmentMemberRepository.findByPostAndUser(post, user)
             .ifPresent(RecruitmentMember::validateCanApply);
 
+        // 정원 초과 검증
+        post.validateCapacity();
+
         recruitmentMemberRepository.save(RecruitmentMember.participant(post, user));
         return post.getId();
     }
@@ -68,7 +71,6 @@ public class RecruitmentMemberService {
         switch (reqDto.getStatus()) {
             case MemberStatus.APPROVED -> {
                 post.increaseCurrentCount();
-                member.approve();
             }
 
             case MemberStatus.REJECTED -> {

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -1,0 +1,29 @@
+package com.example.sesacrunback.domain.recruitment.member.service;
+
+import com.example.sesacrunback.domain.recruitment.member.entity.RecruitmentMember;
+import com.example.sesacrunback.domain.recruitment.member.repository.RecruitmentMemberRepository;
+import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
+import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.global.exception.CustomException;
+import com.example.sesacrunback.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecruitmentMemberService {
+
+    private final RecruitmentMemberRepository recruitmentMemberRepository;
+
+    public void createRecruitment(RecruitmentPost post, User user) {
+        
+        // 이미 등록된 멤버인지
+        if (recruitmentMemberRepository.existsByPostAndUser(post, user)) {
+            throw new CustomException(ErrorCode.ALREADY_RECRUITED_MEMBER);
+        }
+        recruitmentMemberRepository.save(RecruitmentMember.of(post, user));
+    }
+
+}

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -40,7 +40,7 @@ public class RecruitmentMemberService {
         User user = getUserById(userId);
 
         // 이미 신청 여부 검증
-        recruitmentMemberRepository.findByPostAndUser(post, user)
+        recruitmentMemberRepository.findTopByPostAndUserOrderByCreatedAtDesc(post, user)
             .ifPresent(RecruitmentMember::validateCanApply);
 
         // 정원 초과 검증
@@ -51,7 +51,8 @@ public class RecruitmentMemberService {
     }
 
     @Transactional
-    public void updateMemberStatus(Long postId, Long memberId, Long userId, MemberUpdateReqDto reqDto) {
+    public void updateMemberStatus(Long postId, Long memberId, Long userId,
+        MemberUpdateReqDto reqDto) {
 
         RecruitmentPost post = getPostById(postId);
         User user = getUserById(userId);

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -22,7 +22,7 @@ public class RecruitmentMemberService {
     private final UserRepository userRepository;
 
     public void createRecruitment(RecruitmentPost post, User user) {
-        
+
         // 이미 등록된 멤버인지
         if (recruitmentMemberRepository.existsByPostAndUser(post, user)) {
             throw new CustomException(ErrorCode.ALREADY_RECRUITED_MEMBER);
@@ -33,11 +33,9 @@ public class RecruitmentMemberService {
     @Transactional
     public Long applyToRecruitment(Long postId, Long userId) {
 
-        RecruitmentPost post = recruitmentPostRepository.findById(postId)
-            .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        RecruitmentPost post = getPostById(postId);
 
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        User user = getUserById(userId);
 
         // 이미 신청 여부 검증
         recruitmentMemberRepository.findByPostAndUser(post, user)
@@ -45,5 +43,16 @@ public class RecruitmentMemberService {
 
         recruitmentMemberRepository.save(RecruitmentMember.participant(post, user));
         return post.getId();
+    }
+
+
+    private RecruitmentPost getPostById(Long postId) {
+        return recruitmentPostRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -70,6 +70,7 @@ public class RecruitmentMemberService {
 
         switch (reqDto.getStatus()) {
             case MemberStatus.APPROVED -> {
+                member.approve();
                 post.increaseCurrentCount();
             }
 

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -3,7 +3,9 @@ package com.example.sesacrunback.domain.recruitment.member.service;
 import com.example.sesacrunback.domain.recruitment.member.entity.RecruitmentMember;
 import com.example.sesacrunback.domain.recruitment.member.repository.RecruitmentMemberRepository;
 import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
+import com.example.sesacrunback.domain.recruitment.post.repository.RecruitmentPostRepository;
 import com.example.sesacrunback.domain.user.entity.User;
+import com.example.sesacrunback.domain.user.repository.UserRepository;
 import com.example.sesacrunback.global.exception.CustomException;
 import com.example.sesacrunback.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecruitmentMemberService {
 
     private final RecruitmentMemberRepository recruitmentMemberRepository;
+    private final RecruitmentPostRepository recruitmentPostRepository;
+    private final UserRepository userRepository;
 
     public void createRecruitment(RecruitmentPost post, User user) {
         
@@ -26,4 +30,20 @@ public class RecruitmentMemberService {
         recruitmentMemberRepository.save(RecruitmentMember.organizer(post, user));
     }
 
+    @Transactional
+    public Long applyToRecruitment(Long postId, Long userId) {
+
+        RecruitmentPost post = recruitmentPostRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 이미 신청 여부 검증
+        recruitmentMemberRepository.findByPostAndUser(post, user)
+            .ifPresent(RecruitmentMember::validateCanApply);
+
+        recruitmentMemberRepository.save(RecruitmentMember.participant(post, user));
+        return post.getId();
+    }
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
@@ -115,7 +115,7 @@ public class RecruitmentPost extends BaseTimeEntity {
         currentMembers++;
     }
 
-    private void validateCapacity() {
+    public void validateCapacity() {
         if (currentMembers >= totalMembers) {
             throw new CustomException(ErrorCode.RECRUITMENT_FULL);
         }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
@@ -98,6 +98,7 @@ public class RecruitmentPost extends BaseTimeEntity {
         this.totalMembers = totalMembers;
     }
 
+    // todo 예외를 여기서 던질지 고민
     public boolean isPostOwner(Long userId) {
         return this.author.getId().equals(userId);
     }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/entity/RecruitmentPost.java
@@ -109,4 +109,15 @@ public class RecruitmentPost extends BaseTimeEntity {
             throw new CustomException(ErrorCode.POST_INVALID_TOTAL_MEMBERS);
         }
     }
+
+    public void increaseCurrentCount() {
+        validateCapacity();
+        currentMembers++;
+    }
+
+    private void validateCapacity() {
+        if (currentMembers >= totalMembers) {
+            throw new CustomException(ErrorCode.RECRUITMENT_FULL);
+        }
+    }
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/service/RecruitmentPostService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/service/RecruitmentPostService.java
@@ -1,5 +1,6 @@
 package com.example.sesacrunback.domain.recruitment.post.service;
 
+import com.example.sesacrunback.domain.recruitment.member.service.RecruitmentMemberService;
 import com.example.sesacrunback.domain.recruitment.post.dto.request.RecruitmentPostCreateReqDto;
 import com.example.sesacrunback.domain.recruitment.post.dto.request.RecruitmentPostUpdateReqDto;
 import com.example.sesacrunback.domain.recruitment.post.dto.response.PostDetailResDto;
@@ -24,6 +25,7 @@ public class RecruitmentPostService {
 
     private final UserRepository userRepository;
     private final RecruitmentPostRepository recruitmentPostRepository;
+    private final RecruitmentMemberService recruitmentMemberService;
 
     @Transactional
     public Long createPost(RecruitmentPostCreateReqDto reqDto, Long userId) {
@@ -33,6 +35,10 @@ public class RecruitmentPostService {
             .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
 
         RecruitmentPost post = recruitmentPostRepository.save(reqDto.toEntity(user));
+
+        // 모집 생성
+        recruitmentMemberService.createRecruitment(post, user);
+
         return post.getId();
     }
 

--- a/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
@@ -16,10 +16,15 @@ public enum ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     POST_NOT_OWNER(HttpStatus.FORBIDDEN, "해당 게시글의 작성자가 아닙니다."),
     POST_INVALID_TOTAL_MEMBERS(HttpStatus.BAD_REQUEST, "모집 인원은 현재 참여 인원보다 적게 설정할 수 없습니다."),
+    RECRUITMENT_FULL(HttpStatus.CONFLICT, "모집 인원이 모두 찼습니다."),
 
     // 모임
     ALREADY_RECRUITED_MEMBER(HttpStatus.CONFLICT, "이미 해당 모임에 참여 중입니다."),
     ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 신청된 모임입니다."),
+    NOT_RECRUITMENT_MEMBER(HttpStatus.FORBIDDEN, "해당 모임의 멤버가 아닙니다."),
+    NOT_RECRUITMENT_ORGANIZER(HttpStatus.FORBIDDEN, "요청을 처리할 권한이 없습니다."),
+    RECRUITED_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "모임 참여 신청을 찾을 수 없습니다."),
+    MEMBER_STATUS_NOT_PENDING(HttpStatus.CONFLICT, "대기 상태가 아닙니다."),
 
 
     // Common

--- a/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     POST_NOT_OWNER(HttpStatus.FORBIDDEN, "해당 게시글의 작성자가 아닙니다."),
     POST_INVALID_TOTAL_MEMBERS(HttpStatus.BAD_REQUEST, "모집 인원은 현재 참여 인원보다 적게 설정할 수 없습니다."),
 
+    // 모집
+    ALREADY_RECRUITED_MEMBER(HttpStatus.CONFLICT, "이미 해당 모집에 참여 중입니다."),
+
     // Common
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),

--- a/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
 
     // 모집
     ALREADY_RECRUITED_MEMBER(HttpStatus.CONFLICT, "이미 해당 모집에 참여 중입니다."),
+    ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 신청된 모임입니다."),
+
 
     // Common
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),

--- a/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/sesacrunback/global/exception/ErrorCode.java
@@ -17,8 +17,8 @@ public enum ErrorCode {
     POST_NOT_OWNER(HttpStatus.FORBIDDEN, "해당 게시글의 작성자가 아닙니다."),
     POST_INVALID_TOTAL_MEMBERS(HttpStatus.BAD_REQUEST, "모집 인원은 현재 참여 인원보다 적게 설정할 수 없습니다."),
 
-    // 모집
-    ALREADY_RECRUITED_MEMBER(HttpStatus.CONFLICT, "이미 해당 모집에 참여 중입니다."),
+    // 모임
+    ALREADY_RECRUITED_MEMBER(HttpStatus.CONFLICT, "이미 해당 모임에 참여 중입니다."),
     ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 신청된 모임입니다."),
 
 


### PR DESCRIPTION
## ✨ 변경 사항

<!-- 어떤 변화가 있었는지 설명해주세요 -->
* 모집 글 작성 시 모임 생성 로직 호출 및 모임 참여, 승인/거절 기능을 구현했습니다.
   * 모집 글 생성 시 모임 생성 및 모집 글을 작성하는 사용자를 모집자(`ORGANIZER`)로 등록되게 하였습니다.
   * 참여 신청 시 상태 기반 검증 로직 적용 (`PENDING`, `APPROVED` 상태인 경우 재신청 불가) 했습니다.
   * 참여 신청 승인 / 거절 로직은 엔티티 메서드로 캡슐화하였습니다.

## 🔍 관련 이슈
* 포스트맨 테스트 중 모집자가 특정 사용자의 참여 신청을 거절(`REJECTED`)한 이후 해당 사용자가 다시 신청할 경우 서버 에러(`NonUniqueResultException`)가 발생했습니다.
* 기존에 사용하던 `findByPostAndUser` 메서드는 `post + user` 기준으로 단건을 조회하는데 참여 신청 시 검증 로직은 `PENDING`, `APPROVED` 상태에서만 예외를 발생시키고, `REJECTED` 상태의 경우에는 재신청이 가능하도록 새로운 row를 insert하도록 설계되어 있었습니다.
* 이로 인해 동일한 사용자가
1. 신청 -> 거절
2. 재신청 -> 거절
3. 다시 신청
하는 과정에서 동일한 `post + user` 조합에 여러 개의 row가 누적되었고 단건 조회를 가정한 `findByPostAndUser` 호출 시 조회 결과가 2건 이상 반환되면서 에러가 발생했습니다.

* 이를 해결하기 위해 repository 메서드를 `findTopByPostAndUserOrderByCreatedAtDesc`로 수정하여 항상 가장 최근 신청 1건의 상태를 기준으로 신청 가능 여부를 판단하도록 변경했습니다.

- close #18 

## 📌 작업 내용

- [x] 기능 구현
- [ ] 테스트 작성
- [ ] 리팩토링

## 🧪 테스트 방법
1. 모집 글 생성 API 호출 `http://localhost:8080/api/recruitments/posts`
    * 작성자가 자동으로 ORGANIZER / APPROVED 상태로 등록되는지 확인
```json
body
{
    "category" : "study",
    "title" : "모집합니다.",
    "content" : "같이 공부하실 분",
    "totalMembers" : 2
}
```

5. 참여 신청 `http://localhost:8080/api/recruitments/{postId}/members`
    * 최초 신청 → PENDING
    * 승인 시 → APPROVED
    * 거절 시 → REJECTED

6. 모임 신청 상태 변경 (승인/거절) `http://localhost:8080/api/recruitments/{postId}/members/{memberId}`
```json
body
{
    "status" : "APPROVED" or "REJECTED"
}
```

7. 거절된 사용자 재신청
    * 서버 에러 없이 정상적으로 재신청되는지 확인
    * 가장 최근 신청 상태 기준으로 검증되는지 확인
<!-- 어떻게 테스트할 수 있는지 설명해주세요 -->

## 📎 기타 참고사항

<!-- 리뷰어가 참고하면 좋을 내용 -->
