### PR TITLE
코스 디테일 페이지 권한 수정 및 구매하기 클릭 시 CartController api 연결

### DIFF
--- a/src/main/java/com/example/sesacrunback/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/sesacrunback/domain/cart/controller/CartController.java
@@ -25,9 +25,6 @@ public class CartController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody CartCreateRequest request
     ) {
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
         CartResponse response = cartService.create(userDetails.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -36,9 +33,6 @@ public class CartController {
     public ResponseEntity<ApiResponse<List<CartResponse>>> findAll(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
         List<CartResponse> carts = cartService.findAll(userDetails.getId());
         return ResponseEntity.ok(ApiResponse.success(carts));
     }
@@ -48,9 +42,6 @@ public class CartController {
             @PathVariable("itemId") Long itemId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
         cartService.delete(itemId, userDetails.getId());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/sesacrunback/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/sesacrunback/domain/cart/controller/CartController.java
@@ -4,12 +4,12 @@ import com.example.sesacrunback.domain.cart.dto.request.CartCreateRequest;
 import com.example.sesacrunback.domain.cart.dto.response.CartResponse;
 import com.example.sesacrunback.domain.cart.service.CartService;
 import com.example.sesacrunback.global.common.dto.ApiResponse;
-//import com.example.sesacrunback.global.security.CustomUserDetails;
+import com.example.sesacrunback.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,50 +17,41 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/carts")
 @RequiredArgsConstructor
-
 public class CartController {
     private final CartService cartService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CartResponse>> create(
-            @RequestHeader("X-USER-ID") Long userId, // @AuthenticationPrincipal 대신 @RequestHeader 사용   // TODO : user 생성 후 변경
-            //@AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody CartCreateRequest request
-    )
-    {
-//        if (userDetails == null) {
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-//        }
-//        CartResponse response = cartService.create(userDetails.getId(), request);
-        CartResponse response = cartService.create(userId, request);
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        CartResponse response = cartService.create(userDetails.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<CartResponse>>> findAll(
-            @RequestHeader("X-USER-ID") Long userId // @AuthenticationPrincipal 대신 @RequestHeader 사용   // TODO : user 생성 후 변경
-            //@AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-//        if (userDetails == null) {
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-//        }
-//        List<CartResponse> carts = cartService.findAll(userDetails.getId());
-        List<CartResponse> carts = cartService.findAll(userId);
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        List<CartResponse> carts = cartService.findAll(userDetails.getId());
         return ResponseEntity.ok(ApiResponse.success(carts));
     }
 
-    @DeleteMapping("/{itemId}") // 요청 경로 변경
+    @DeleteMapping("/{itemId}")
     public ResponseEntity<Void> delete(
             @PathVariable("itemId") Long itemId,
-            @RequestHeader("X-USER-ID") Long userId // @AuthenticationPrincipal 대신 @RequestHeader 사용   // TODO : user 생성 후 변경
-            //@AuthenticationPrincipal CustomUserDetails userDetails
-
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-//        if (userDetails == null) {
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-//        }
-//        cartService.delete(itemId, userDetails.getId());
-        cartService.delete(itemId, userId);
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        cartService.delete(itemId, userDetails.getId());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/sesacrunback/domain/course/course/controller/CourseController.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/controller/CourseController.java
@@ -4,8 +4,10 @@ import com.example.sesacrunback.domain.course.course.dto.request.CourseUpdateReq
 import com.example.sesacrunback.domain.course.course.dto.request.CreateCourseRequest;
 import com.example.sesacrunback.domain.course.course.dto.response.CourseDetailResponse;
 import com.example.sesacrunback.domain.course.course.dto.response.CourseResponse;
+import com.example.sesacrunback.domain.course.course.dto.response.CourseWatchResponse;
 import com.example.sesacrunback.domain.course.course.service.CourseService;
 import com.example.sesacrunback.global.common.dto.ApiResponse;
+import com.example.sesacrunback.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,6 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -32,8 +35,19 @@ public class CourseController {
 
     @GetMapping("/{courseId}")
     public ResponseEntity<ApiResponse<CourseDetailResponse>> getCourseDetail(
-            @PathVariable Long courseId) {
-        CourseDetailResponse course = courseService.getCourseDetail(courseId);
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails != null ? userDetails.getId() : null;
+        CourseDetailResponse course = courseService.getCourseDetail(courseId, userId);
+        return ResponseEntity.ok(ApiResponse.success(course));
+    }
+
+    @GetMapping("/{courseId}/watch")
+    public ResponseEntity<ApiResponse<CourseWatchResponse>> watchCourse(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+        CourseWatchResponse course = courseService.getCourseForWatch(courseId, userId);
         return ResponseEntity.ok(ApiResponse.success(course));
     }
 
@@ -63,8 +77,10 @@ public class CourseController {
     @PostMapping
     // @PreAuthorize("hasRole('INSTRUCTOR')") // 인증 시스템 협업 중이므로 주석 처리
     public ResponseEntity<ApiResponse<CourseResponse>> createCourse(
-            @Valid @RequestBody CreateCourseRequest request) {
-        CourseResponse course = courseService.createCourse(request);
+            @Valid @RequestBody CreateCourseRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long instructorId = userDetails.getId();
+        CourseResponse course = courseService.createCourse(request, instructorId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(course));
     }
@@ -72,8 +88,10 @@ public class CourseController {
     @GetMapping("/my")
     // @PreAuthorize("hasRole('INSTRUCTOR')") // 인증 시스템 협업 중이므로 주석 처리
     public ResponseEntity<ApiResponse<Page<CourseResponse>>> getMyCourses(
-            @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<CourseResponse> courses = courseService.getMyCourses(pageable);
+            @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long instructorId = userDetails.getId();
+        Page<CourseResponse> courses = courseService.getMyCourses(pageable, instructorId);
         return ResponseEntity.ok(ApiResponse.success(courses));
     }
 
@@ -81,16 +99,20 @@ public class CourseController {
     // @PreAuthorize("hasRole('INSTRUCTOR')") // 인증 시스템 협업 중이므로 주석 처리
     public ResponseEntity<ApiResponse<Long>> updateCourse(
             @PathVariable Long courseId,
-            @Valid @RequestBody CourseUpdateReqDto request) {
-        Long updatedCourseId = courseService.updateCourse(courseId, request);
+            @Valid @RequestBody CourseUpdateReqDto request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+        Long updatedCourseId = courseService.updateCourse(courseId, request, userId);
         return ResponseEntity.ok(ApiResponse.success(updatedCourseId));
     }
 
     @DeleteMapping("/{courseId}")
     // @PreAuthorize("hasRole('INSTRUCTOR')") // 인증 시스템 협업 중이므로 주석 처리
     public ResponseEntity<ApiResponse<Void>> deleteCourse(
-            @PathVariable Long courseId) {
-        courseService.deleteCourse(courseId);
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+        courseService.deleteCourse(courseId, userId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/CourseDetailResponse.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/CourseDetailResponse.java
@@ -24,6 +24,10 @@ public class CourseDetailResponse {
     private final Integer studentCount;
     private final List<String> features;
     private final CourseStatus status;
+
+    /** 버튼 분기용 */
+    private final boolean canWatch;
+
     private final List<SectionResponse> sections;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
@@ -41,8 +45,35 @@ public class CourseDetailResponse {
                 course.getStudentCount(),
                 course.getFeatures(),
                 course.getStatus(),
+                false,
                 course.getSections().stream()
                         .map(SectionResponse::from)
+                        .collect(Collectors.toList()),
+                course.getCreatedAt(),
+                course.getUpdatedAt()
+        );
+    }
+
+    public static CourseDetailResponse from(
+            Course course,
+            CourseViewContext ctx,
+            boolean canWatch
+    ) {
+        return new CourseDetailResponse(
+                course.getId(),
+                course.getInstructorId(),
+                course.getTitle(),
+                course.getDescription(),
+                course.getDetailedDescription(),
+                course.getThumbnail(),
+                course.getCategory(),
+                course.getPrice(),
+                course.getStudentCount(),
+                course.getFeatures(),
+                course.getStatus(),
+                canWatch,
+                course.getSections().stream()
+                        .map(s -> SectionResponse.from(s, ctx))
                         .collect(Collectors.toList()),
                 course.getCreatedAt(),
                 course.getUpdatedAt()

--- a/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/CourseViewContext.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/CourseViewContext.java
@@ -1,0 +1,6 @@
+package com.example.sesacrunback.domain.course.course.dto.response;
+
+public record CourseViewContext(
+        boolean isInstructor
+) {
+}

--- a/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/CourseWatchResponse.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/CourseWatchResponse.java
@@ -1,0 +1,84 @@
+package com.example.sesacrunback.domain.course.course.dto.response;
+
+import com.example.sesacrunback.domain.course.course.entity.Course;
+import com.example.sesacrunback.domain.course.lecture.entity.Lecture;
+import com.example.sesacrunback.domain.course.section.entity.Section;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class CourseWatchResponse {
+
+    private final Long courseId;
+    private final String title;
+    private final List<SectionResponse> sections;
+
+    private CourseWatchResponse(Long courseId, String title, List<SectionResponse> sections) {
+        this.courseId = courseId;
+        this.title = title;
+        this.sections = sections;
+    }
+
+    public static CourseWatchResponse from(Course course) {
+        return new CourseWatchResponse(
+                course.getId(),
+                course.getTitle(),
+                course.getSections().stream()
+                        .map(SectionResponse::from)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    @Getter
+    private static class SectionResponse {
+        private final Long id;
+        private final String title;
+        private final List<LectureResponse> lectures;
+
+        private SectionResponse(Long id, String title, List<LectureResponse> lectures) {
+            this.id = id;
+            this.title = title;
+            this.lectures = lectures;
+        }
+
+        private static SectionResponse from(Section section) {
+            return new SectionResponse(
+                    section.getId(),
+                    section.getTitle(),
+                    section.getLectures().stream()
+                            .map(LectureResponse::from)
+                            .collect(Collectors.toList())
+            );
+        }
+    }
+
+    @Getter
+    private static class LectureResponse {
+        private final Long id;
+        private final String title;
+        private final String videoUrl;
+        private final Integer duration;
+        private final Integer order;
+
+        private LectureResponse(Long id, String title, String videoUrl,
+                                Integer duration, Integer order) {
+            this.id = id;
+            this.title = title;
+            this.videoUrl = videoUrl;
+            this.duration = duration;
+            this.order = order;
+        }
+
+        private static LectureResponse from(Lecture lecture) {
+            return new LectureResponse(
+                    lecture.getId(),
+                    lecture.getTitle(),
+                    lecture.getVideoUrl(),
+                    lecture.getDuration(),
+                    lecture.getOrder()
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
@@ -4,8 +4,11 @@ import com.example.sesacrunback.domain.course.course.dto.request.CourseUpdateReq
 import com.example.sesacrunback.domain.course.course.dto.request.CreateCourseRequest;
 import com.example.sesacrunback.domain.course.course.dto.response.CourseDetailResponse;
 import com.example.sesacrunback.domain.course.course.dto.response.CourseResponse;
+import com.example.sesacrunback.domain.course.course.dto.response.CourseViewContext;
+import com.example.sesacrunback.domain.course.course.dto.response.CourseWatchResponse;
 import com.example.sesacrunback.domain.course.course.entity.Course;
 import com.example.sesacrunback.domain.course.course.repository.CourseRepository;
+import com.example.sesacrunback.domain.order.repository.OrderRepository;
 import com.example.sesacrunback.domain.course.lecture.entity.Lecture;
 import com.example.sesacrunback.domain.user.entity.User;
 import com.example.sesacrunback.global.exception.CustomException;
@@ -31,22 +34,14 @@ public class CourseService {
 
     private final CourseRepository courseRepository;
     private final EntityManager entityManager;
-
-    /**
-     * 현재 로그인한 사용자 ID 반환 (더미)
-     */
-    private Long getCurrentUserId() {
-        return 1L; // 임시 강의자 ID
-    }
+    private final OrderRepository orderRepository;
 
     /**
      * 강의 생성 (Phase 1: 생성 즉시 게시)
      */
     @Transactional
-    public CourseResponse createCourse(CreateCourseRequest request) {
+    public CourseResponse createCourse(CreateCourseRequest request, Long instructorId) {
         log.info("Creating new course: {}", request.getTitle());
-
-        Long instructorId = getCurrentUserId();
 
         // User 프록시 생성 (실제 DB 조회 없이 참조만 생성)
         User instructor = entityManager.getReference(User.class, instructorId);
@@ -57,14 +52,41 @@ public class CourseService {
         return CourseResponse.from(courseRepository.save(course));
     }
 
-    public CourseDetailResponse getCourseDetail(Long courseId) {
+    /**
+     * 상세 페이지 (미리보기 + 버튼 분기)
+     */
+    public CourseDetailResponse getCourseDetail(Long courseId, Long userId) {
         log.info("Getting course detail for ID: {}", courseId);
 
         // sections 조회 (lectures는 @BatchSize로 자동 로딩)
         Course course = courseRepository.findDetailWithSections(courseId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
-        return CourseDetailResponse.from(course);
+        boolean isInstructor = userId != null && course.isOwner(userId);
+        boolean canWatch = userId != null &&
+                (isInstructor ||
+                 orderRepository.hasCompletedOrderForCourse(userId, courseId));
+
+        CourseViewContext ctx = new CourseViewContext(isInstructor);
+
+        return CourseDetailResponse.from(course, ctx, canWatch);
+    }
+
+    /**
+     * Watch 페이지 (강사 or 구매자만 전체 시청)
+     */
+    public CourseWatchResponse getCourseForWatch(Long courseId, Long userId) {
+        log.info("Getting course for watch - courseId: {}, userId: {}", courseId, userId);
+
+        Course course = courseRepository.findDetailWithSections(courseId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        if (!course.isOwner(userId)
+                && !orderRepository.hasCompletedOrderForCourse(userId, courseId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        return CourseWatchResponse.from(course);
     }
 
     /**
@@ -118,8 +140,7 @@ public class CourseService {
     /**
      * 강사의 강의 목록 조회 (페이징)
      */
-    public Page<CourseResponse> getMyCourses(Pageable pageable) {
-        Long instructorId = getCurrentUserId();
+    public Page<CourseResponse> getMyCourses(Pageable pageable, Long instructorId) {
         log.info("Getting courses for instructor ID: {}", instructorId);
 
         return courseRepository.findByInstructor_Id(instructorId, pageable)
@@ -130,12 +151,11 @@ public class CourseService {
      * 강의 수정
      */
     @Transactional
-    public Long updateCourse(Long courseId, CourseUpdateReqDto reqDto) {
+    public Long updateCourse(Long courseId, CourseUpdateReqDto reqDto, Long userId) {
         log.info("Updating course with ID: {}", courseId);
 
         Course course = getCourseById(courseId);
-        Long currentUserId = getCurrentUserId();
-        validateCourseOwner(course, currentUserId);
+        validateCourseOwner(course, userId);
 
         course.updateCourse(
                 reqDto.getTitle(),
@@ -154,12 +174,11 @@ public class CourseService {
      * 강의 삭제
      */
     @Transactional
-    public void deleteCourse(Long courseId) {
+    public void deleteCourse(Long courseId, Long userId) {
         log.info("Deleting course with ID: {}", courseId);
 
         Course course = getCourseById(courseId);
-        Long currentUserId = getCurrentUserId();
-        validateCourseOwner(course, currentUserId);
+        validateCourseOwner(course, userId);
 
         courseRepository.delete(course);
     }

--- a/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
@@ -62,10 +62,10 @@ public class CourseService {
         Course course = courseRepository.findDetailWithSections(courseId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
-        boolean isInstructor = userId != null && course.isOwner(userId);
-        boolean canWatch = userId != null &&
-                (isInstructor ||
-                 orderRepository.hasCompletedOrderForCourse(userId, courseId));
+        final boolean isUserLoggedIn = userId != null;
+        final boolean isInstructor = isUserLoggedIn && course.isOwner(userId);
+        final boolean hasPurchased = isUserLoggedIn && orderRepository.hasCompletedOrderForCourse(userId, courseId);
+        final boolean canWatch = isInstructor || hasPurchased;
 
         CourseViewContext ctx = new CourseViewContext(isInstructor);
 

--- a/src/main/java/com/example/sesacrunback/domain/course/lecture/dto/response/LectureResponse.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/lecture/dto/response/LectureResponse.java
@@ -1,5 +1,6 @@
 package com.example.sesacrunback.domain.course.lecture.dto.response;
 
+import com.example.sesacrunback.domain.course.course.dto.response.CourseViewContext;
 import com.example.sesacrunback.domain.course.lecture.entity.Lecture;
 import lombok.Getter;
 
@@ -29,6 +30,21 @@ public class LectureResponse {
                 lecture.getDuration(),
                 lecture.getOrder(),
                 lecture.getVideoUrl(),
+                lecture.getIsFree()
+        );
+    }
+
+    /** /courses/{id} 정책 - 미리보기 */
+    public static LectureResponse from(Lecture lecture, CourseViewContext ctx) {
+        boolean canWatchPreview =
+                ctx.isInstructor() || Boolean.TRUE.equals(lecture.getIsFree());
+
+        return new LectureResponse(
+                lecture.getId(),
+                lecture.getTitle(),
+                lecture.getDuration(),
+                lecture.getOrder(),
+                canWatchPreview ? lecture.getVideoUrl() : null,
                 lecture.getIsFree()
         );
     }

--- a/src/main/java/com/example/sesacrunback/domain/course/section/dto/response/SectionResponse.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/section/dto/response/SectionResponse.java
@@ -1,5 +1,6 @@
 package com.example.sesacrunback.domain.course.section.dto.response;
 
+import com.example.sesacrunback.domain.course.course.dto.response.CourseViewContext;
 import com.example.sesacrunback.domain.course.lecture.dto.response.LectureResponse;
 import com.example.sesacrunback.domain.course.section.entity.Section;
 import lombok.Getter;
@@ -28,6 +29,17 @@ public class SectionResponse {
                 section.getOrder(),
                 section.getLectures().stream()
                         .map(LectureResponse::from)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public static SectionResponse from(Section section, CourseViewContext ctx) {
+        return new SectionResponse(
+                section.getId(),
+                section.getTitle(),
+                section.getOrder(),
+                section.getLectures().stream()
+                        .map(l -> LectureResponse.from(l, ctx))
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/com/example/sesacrunback/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/order/repository/OrderRepository.java
@@ -11,7 +11,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     /**
      * 유저가 해당 코스를 결제 완료(COMPLETED) 상태로 구매했는지 여부
      */
-    boolean existsByUserIdAndOrderItems_CourseIdAndStatus(
+    boolean existsByUserIdAndOrderItems_Course_IdAndStatus(
             Long userId,
             Long courseId,
             OrderState status
@@ -19,7 +19,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     /** 수강 권한 판단 단일 진입점 */
     default boolean hasCompletedOrderForCourse(Long userId, Long courseId) {
-        return existsByUserIdAndOrderItems_CourseIdAndStatus(
+        return existsByUserIdAndOrderItems_Course_IdAndStatus(
                 userId,
                 courseId,
                 OrderState.COMPLETED

--- a/src/main/java/com/example/sesacrunback/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sesacrunback/global/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/courses/my").hasRole("INSTRUCTOR") // 조회: 강사
                         .requestMatchers(HttpMethod.POST,"/api/courses").hasRole("INSTRUCTOR") // 작성: 강사
                         .requestMatchers(HttpMethod.DELETE,"/api/courses/**").hasRole("INSTRUCTOR") // 삭제: 강사
+                        .requestMatchers(HttpMethod.GET, "/api/courses/*/watch").authenticated() // Watch: 로그인 필요 (구매 권한은 Service에서 체크)
                         .requestMatchers(HttpMethod.GET, "/api/courses/**").permitAll() // 조회: 누구나
                         
                         // 커뮤니티
@@ -51,7 +52,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/recruitments/posts/**").authenticated()  // 삭제: 로그인 필요
                         
                         // 장바구니
-                        .requestMatchers("/api/cart/**").authenticated() //장바구니 모든 요청 : 로그인 필요
+                        .requestMatchers("/api/carts/**").authenticated() //장바구니 모든 요청 : 로그인 필요
 
                         .anyRequest().authenticated()
         

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -26,10 +26,10 @@ INSERT INTO sections (title, section_order, course_id, created_at, updated_at) V
 
 -- Lectures
 INSERT INTO lectures (title, video_url, duration, is_free, lecture_order, section_id, created_at, updated_at) VALUES
-('변수와 자료형', 'https://youtu.be/example1', 600, true, 1, 1, NOW(), NOW()),
-('연산자', 'https://youtu.be/example2', 900, false, 2, 1, NOW(), NOW()),
-('클래스와 객체', 'https://youtu.be/example3', 1200, false, 1, 2, NOW(), NOW()),
-('스프링 프로젝트 생성', 'https://youtu.be/example4', 720, true, 1, 3, NOW(), NOW());
+('변수와 자료형', 'https://www.youtube.com/watch?v=yZ89etxVBKs', 600, true, 1, 1, NOW(), NOW()),
+('연산자', 'https://www.youtube.com/watch?v=yZ89etxVBKs', 900, false, 2, 1, NOW(), NOW()),
+('클래스와 객체', 'https://www.youtube.com/watch?v=yZ89etxVBKs', 1200, false, 1, 2, NOW(), NOW()),
+('스프링 프로젝트 생성', 'https://www.youtube.com/watch?v=yZ89etxVBKs', 720, true, 1, 3, NOW(), NOW());
 
 -- Recruitment Posts
 INSERT INTO recruitment_posts (category, status, title, content, current_members, total_members, views, author_id, created_at, updated_at) VALUES
@@ -70,3 +70,36 @@ INSERT INTO payments (portone_payment_id, amount, status, order_id, created_at, 
 -- Cart Items
 INSERT INTO cart_items (user_id, course_id, created_at) VALUES
 (3, 2, NOW());
+
+-- ✅ COMPLETED Order (이학생이 자바 완전 정복 구매 완료)
+
+INSERT INTO orders (
+    order_number,
+    total_amount,
+    status,
+    user_id,
+    created_at,
+    updated_at
+) VALUES (
+             'ORD-20231222-0002',
+             50000,
+             'COMPLETED',
+             2,
+             NOW(),
+             NOW()
+         );
+
+-- 해당 주문에 포함된 강의 (자바 완전 정복)
+INSERT INTO order_items (
+    course_name,
+    price,
+    order_id,
+    course_id,
+    created_at
+) VALUES (
+             '자바 완전 정복',
+             50000,
+             LAST_INSERT_ID(),
+             1,
+             NOW()
+         );


### PR DESCRIPTION
## ✨ 변경 사항
- 코스 디테일 페이지에서 수강 권한 수정
- 수경님 요청으로 인해 "장바구니" 버튼은 일단 삭제
- "구매하기" 클릭 시 CartController에서 api 호출 및 cart 페이지로 이동 
- 이미 구매한 강의이거나, 강사 본인인 경우 "이어보기"
- 미리보기 페이지와 watch 페이지에서 유튜브 스트리밍 강의 구현

## 🔍 관련 이슈


## 📌 작업 내용

- [v] 기능 구현
- [ ] 테스트 작성
- [ ] 리팩토링

## 🧪 테스트 방법
<!-- 어떻게 테스트할 수 있는지 설명해주세요 -->
user1@test.com
password123 로 로그인하면 '자바 기초부터 심화까지'는 구매한 강의여서 바로 강의 시청이 가능, 
'스프링 부트 입문'는 구매하지 않았기 때문에 cart 페이지로 이동합니다. 

## 📎 기타 참고사항

<!-- 리뷰어가 참고하면 좋을 내용 --> 
*수경님 참고사항 
- Security Config에서 watch 관련 api 추가하였습니다. 
- CartController에서 @AuthenticationPrincipal 처리를 추가하였습니다.  
- CartRespository에서 함수명 변경이 있었습니다. 
