### PR TITLE
Fix: 모임 신청 거절 후 재신청 시 상태 update하도록 수정

### DIFF
--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
@@ -67,13 +67,15 @@ public class RecruitmentMember extends BaseTimeEntity { //todo 추후 패키지,
     }
 
     public void validateCanApply() {
-        if (status == MemberStatus.PENDING) {
-            throw new CustomException(ErrorCode.ALREADY_APPLIED);
+
+        switch (status) {
+            case PENDING -> throw new CustomException(ErrorCode.ALREADY_APPLIED);
+            case APPROVED -> throw new CustomException(ErrorCode.ALREADY_RECRUITED_MEMBER);
+            case REJECTED -> {
+                status = MemberStatus.PENDING;
+            }
         }
 
-        if (status == MemberStatus.APPROVED) {
-            throw new CustomException(ErrorCode.ALREADY_RECRUITED_MEMBER);
-        }
     }
 
     public boolean isOrganizer() {

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/entity/RecruitmentMember.java
@@ -66,7 +66,7 @@ public class RecruitmentMember extends BaseTimeEntity { //todo 추후 패키지,
             .build();
     }
 
-    public void validateCanApply() {
+    public void reapply() {
 
         switch (status) {
             case PENDING -> throw new CustomException(ErrorCode.ALREADY_APPLIED);

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -10,6 +10,7 @@ import com.example.sesacrunback.domain.user.entity.User;
 import com.example.sesacrunback.domain.user.repository.UserRepository;
 import com.example.sesacrunback.global.exception.CustomException;
 import com.example.sesacrunback.global.exception.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,8 +41,15 @@ public class RecruitmentMemberService {
         User user = getUserById(userId);
 
         // 이미 신청 여부 검증
-        recruitmentMemberRepository.findTopByPostAndUserOrderByCreatedAtDesc(post, user)
-            .ifPresent(RecruitmentMember::validateCanApply);
+        Optional<RecruitmentMember> optionalMember = recruitmentMemberRepository.findByPostAndUser(
+            post, user);
+
+        // 이미 존재한다면 신청 검증
+        if (optionalMember.isPresent()) {
+            RecruitmentMember member = optionalMember.get();
+            member.validateCanApply();
+            return post.getId();
+        }
 
         // 정원 초과 검증
         post.validateCapacity();

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/member/service/RecruitmentMemberService.java
@@ -47,7 +47,7 @@ public class RecruitmentMemberService {
         // 이미 존재한다면 신청 검증
         if (optionalMember.isPresent()) {
             RecruitmentMember member = optionalMember.get();
-            member.validateCanApply();
+            member.reapply();
             return post.getId();
         }
 


### PR DESCRIPTION
## ✨ 변경 사항

<!-- 어떤 변화가 있었는지 설명해주세요 -->
* 모집자가 모임 신청을 거절한 후 해당 사용자가 다시 재신청 시 새로운 행을 insert하는 방식으로 인해서 단건 조회 전제의 메서드에서 에러가 발생했었고, 이를 해결하기 위해 거절된 사용자가 재신청 시에는 상태를 update하는 방식으로 수정했습니다. 관련 이슈에 내용 작성해두었으니 궁금하신 분들은 확인해보시면 좋을 것 같아요.

## 🔍 관련 이슈

- close #35 

## 📌 작업 내용

- [ ] 기능 구현
- [ ] 테스트 작성
- [x] 리팩토링

## 🧪 테스트 방법

<!-- 어떻게 테스트할 수 있는지 설명해주세요 -->

## 📎 기타 참고사항

<!-- 리뷰어가 참고하면 좋을 내용 -->
