### PR TITLE
Feat: 게시글 조회 시 응답 필드 추가 및 인증 객체에서 사용자 추출 로직 추가

### DIFF
--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/controller/RecruitmentPostController.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/controller/RecruitmentPostController.java
@@ -15,7 +15,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,7 +47,7 @@ public class RecruitmentPostController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostDetailResDto>> viewPost(@PathVariable Long postId) {
-        return ResponseEntity.ok(ApiResponse.success(recruitmentPostService.viewPost(postId)));
+        return ResponseEntity.ok(ApiResponse.success(recruitmentPostService.viewPost(postId, getLoginUserId())));
     }
 
     @GetMapping
@@ -54,7 +57,7 @@ public class RecruitmentPostController {
         @PageableDefault Pageable pageable) {
 
         return ResponseEntity.ok(
-            ApiResponse.success(recruitmentPostService.viewPosts(category, status, pageable)));
+            ApiResponse.success(recruitmentPostService.viewPosts(category, status, pageable, getLoginUserId())));
     }
 
     @PutMapping("/{postId}")
@@ -72,6 +75,15 @@ public class RecruitmentPostController {
         @AuthenticationPrincipal CustomUserDetails userDetails) {
         recruitmentPostService.deletePost(postId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.success("삭제되었습니다."));
+    }
+
+    private Long getLoginUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()
+            || auth instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+        return ((CustomUserDetails) auth.getPrincipal()).getId();
     }
 
 }

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/dto/response/PostDetailResDto.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/dto/response/PostDetailResDto.java
@@ -1,6 +1,7 @@
 package com.example.sesacrunback.domain.recruitment.post.dto.response;
 
 import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentPost;
+import com.example.sesacrunback.domain.recruitment.post.entity.RecruitmentStatus;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,13 @@ public class PostDetailResDto { //Todo 작성자 Id 반환 필요
 
     private final String content;
 
+    private final RecruitmentStatus status;
+
     private final String authorName;
+
+    private final boolean isAuthor;
+
+    private final int views;
 
     private final Integer currentMembers;
 
@@ -23,10 +30,10 @@ public class PostDetailResDto { //Todo 작성자 Id 반환 필요
 
     private final LocalDateTime createdAt;
 
-    public static PostDetailResDto from(RecruitmentPost post) {
+    public static PostDetailResDto from(RecruitmentPost post, boolean isAuthor) {
         return new PostDetailResDto(post.getId(), post.getTitle(), post.getContent(),
-            post.getAuthor().getName(), post.getCurrentMembers(), post.getTotalMembers(),
-            post.getCreatedAt());
+            post.getStatus(), post.getAuthor().getName(), isAuthor, post.getViews(),
+            post.getCurrentMembers(), post.getTotalMembers(), post.getCreatedAt());
     }
 
 

--- a/src/main/java/com/example/sesacrunback/domain/recruitment/post/service/RecruitmentPostService.java
+++ b/src/main/java/com/example/sesacrunback/domain/recruitment/post/service/RecruitmentPostService.java
@@ -31,7 +31,7 @@ public class RecruitmentPostService {
     public Long createPost(RecruitmentPostCreateReqDto reqDto, Long userId) {
 
         User user = userRepository.findById(userId)
-            .orElseThrow(() ->  new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         RecruitmentPost post = recruitmentPostRepository.save(reqDto.toEntity(user));
 
@@ -42,19 +42,21 @@ public class RecruitmentPostService {
     }
 
     @Transactional
-    public PostDetailResDto viewPost(Long postId) {
+    public PostDetailResDto viewPost(Long postId, Long userId) {
         RecruitmentPost post = getPostById(postId);
         // 조회 수 증가
         post.increaseViewCount();
 
-        return PostDetailResDto.from(post);
+        return PostDetailResDto.from(post, userId != null && post.isPostOwner(userId));
     }
 
     public Slice<PostDetailResDto> viewPosts(RecruitmentCategory category, RecruitmentStatus status,
-        Pageable pageable) {
+        Pageable pageable, Long userId) {
         Slice<RecruitmentPost> posts = recruitmentPostRepository.findPosts(category, status,
             pageable);
-        return posts.map(PostDetailResDto::from);
+
+        return posts.map(
+            post -> PostDetailResDto.from(post, userId != null && post.isPostOwner(userId)));
     }
 
     @Transactional


### PR DESCRIPTION
## ✨ 변경 사항

<!-- 어떤 변화가 있었는지 설명해주세요 -->
* 모집 글 상세조회 시 로그인한 사용자가 글 작성자라면 프론트에서 수정/삭제 버튼 노출 처리를 쉽게 할 수 있도록 User 객체 추출
* 프론트에서 필요한 필드를 내려주기 위해 DTO에 필드 추가
   * `status`, `isAuthor`, `views`

## 🔍 관련 이슈

- close #39 

## 📌 작업 내용

- [x] 기능 구현
- [ ] 테스트 작성
- [x] 리팩토링

## 🧪 테스트 방법

<!-- 어떻게 테스트할 수 있는지 설명해주세요 -->

## 📎 기타 참고사항

<!-- 리뷰어가 참고하면 좋을 내용 -->
