### PR TITLE
59 구매내역 상세페이지 추가

### DIFF
--- a/src/main/java/com/example/sesacrunback/domain/cart/controller/ExController.java
+++ b/src/main/java/com/example/sesacrunback/domain/cart/controller/ExController.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.cart.controller;
-
-public class ExController {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/cart/repository/ExRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/cart/repository/ExRepository.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.cart.repository;
-
-public interface ExRepository {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/cart/service/ExService.java
+++ b/src/main/java/com/example/sesacrunback/domain/cart/service/ExService.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.cart.service;
-
-public class ExService {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/order/dto/response/PurchaseOrderResponse.java
+++ b/src/main/java/com/example/sesacrunback/domain/order/dto/response/PurchaseOrderResponse.java
@@ -1,6 +1,7 @@
 package com.example.sesacrunback.domain.order.dto.response;
 
 import com.example.sesacrunback.domain.order.entity.Order;
+import com.example.sesacrunback.domain.order.entity.OrderState;
 import com.example.sesacrunback.domain.orderItem.entity.OrderItem;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,20 +13,24 @@ import java.util.List;
 @Builder
 public class PurchaseOrderResponse {
     private final Long orderId;
+    private final String orderNumber;
     private final String orderTitle;
     private final String thumbnail;
     private final int totalAmount;
-    private final LocalDateTime purchasedAt;
+    private final OrderState status;
+    private final LocalDateTime createdAt;
 
     public static PurchaseOrderResponse from(Order order) {
         List<OrderItem> orderItems = order.getOrderItems();
         if (orderItems == null || orderItems.isEmpty()) {
             return PurchaseOrderResponse.builder()
                     .orderId(order.getId())
+                    .orderNumber(order.getOrderNumber())
                     .orderTitle("주문 항목 없음")
                     .thumbnail(null) // 기본 이미지 URL
                     .totalAmount(order.getPayment() != null ? order.getPayment().getAmount() : 0)
-                    .purchasedAt(order.getCreatedAt())
+                    .createdAt(order.getCreatedAt())
+                    .status(order.getStatus())
                     .build();
         }
 
@@ -35,10 +40,12 @@ public class PurchaseOrderResponse {
 
         return PurchaseOrderResponse.builder()
                 .orderId(order.getId())
+                .orderNumber(order.getOrderNumber())
                 .orderTitle(title)
                 .thumbnail(representativeThumbnail)
                 .totalAmount(paymentAmount)
-                .purchasedAt(order.getCreatedAt())
+                .createdAt(order.getCreatedAt())
+                .status(order.getStatus())
                 .build();
     }
 

--- a/src/main/java/com/example/sesacrunback/domain/orderItem/dto/response/ExResDto.java
+++ b/src/main/java/com/example/sesacrunback/domain/orderItem/dto/response/ExResDto.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.orderItem.dto.response;
-
-public class ExResDto {
-
-}

--- a/src/main/java/com/example/sesacrunback/domain/orderItem/repository/ExRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/orderItem/repository/ExRepository.java
@@ -1,5 +1,0 @@
-package com.example.sesacrunback.domain.orderItem.repository;
-
-public interface ExRepository {
-
-}


### PR DESCRIPTION
## ✨ 변경 사항
 구매상세내역 orderNumber, createdAt 추가

## 🔍 관련 이슈

- close #59 

## 📌 작업 내용
<img width="1281" height="555" alt="image" src="https://github.com/user-attachments/assets/52ff1be0-3eaf-422d-b7cb-3b2c0b0c863a" />


## 🧪 테스트 방법

마이페이지 > 구매내역조회 > 상세페이지 클릭
주문번호와 결제상태 데이터가 올바른지 확인한다.

## 📎 기타 참고사항

<!-- 리뷰어가 참고하면 좋을 내용 -->
