### PR TITLE
목업 데이터 추가 및 운영중인 강의 dto 추가 생성, 총 수익 및 총 수강생 수 계산 로직 추가

### DIFF
--- a/src/main/java/com/example/sesacrunback/domain/course/course/controller/CourseController.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/controller/CourseController.java
@@ -6,6 +6,8 @@ import com.example.sesacrunback.domain.course.course.dto.response.CourseDetailRe
 import com.example.sesacrunback.domain.course.course.dto.response.CourseResponse;
 import com.example.sesacrunback.domain.course.course.dto.response.CourseWatchResponse;
 import com.example.sesacrunback.domain.course.course.dto.response.EnrolledCourseResponse;
+import com.example.sesacrunback.domain.course.course.dto.response.InstructorCourseRevenueDto;
+import com.example.sesacrunback.domain.course.course.dto.response.InstructorStatisticsResDto;
 import com.example.sesacrunback.domain.course.course.service.CourseService;
 import com.example.sesacrunback.global.common.dto.ApiResponse;
 import com.example.sesacrunback.global.security.CustomUserDetails;
@@ -88,12 +90,27 @@ public class CourseController {
 
     @GetMapping("/my")
     // @PreAuthorize("hasRole('INSTRUCTOR')") // 인증 시스템 협업 중이므로 주석 처리
-    public ResponseEntity<ApiResponse<Page<CourseResponse>>> getMyCourses(
+    public ResponseEntity<ApiResponse<Page<InstructorCourseRevenueDto>>> getMyCourses(
             @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long instructorId = userDetails.getId();
-        Page<CourseResponse> courses = courseService.getMyCourses(pageable, instructorId);
+        Page<InstructorCourseRevenueDto> courses = courseService.getMyCourses(pageable, instructorId);
         return ResponseEntity.ok(ApiResponse.success(courses));
+    }
+
+    /**
+     * 강사 통계 조회 (대시보드용)
+     * - 총 강의 수
+     * - 총 수강생 수
+     * - 총 수익
+     */
+    @GetMapping("/my/statistics")
+    // @PreAuthorize("hasRole('INSTRUCTOR')") // 인증 시스템 협업 중이므로 주석 처리
+    public ResponseEntity<ApiResponse<InstructorStatisticsResDto>> getMyStatistics(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long instructorId = userDetails.getId();
+        InstructorStatisticsResDto statistics = courseService.getMyStatistics(instructorId);
+        return ResponseEntity.ok(ApiResponse.success(statistics));
     }
 
     /**

--- a/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/InstructorCourseRevenueDto.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/InstructorCourseRevenueDto.java
@@ -1,0 +1,29 @@
+package com.example.sesacrunback.domain.course.course.dto.response;
+
+import com.example.sesacrunback.domain.course.course.entity.enums.CourseStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강사 대시보드 - 운영 중인 강의 카드 요약 DTO
+ * - id, title, thumbnail, price, studentCount, status, revenue 포함
+ * - JPQL DTO Projection 전용
+ */
+@Getter
+@RequiredArgsConstructor
+public class InstructorCourseRevenueDto {
+
+    private final Long id;
+
+    private final String title;
+
+    private final String thumbnail;
+
+    private final Integer price;
+
+    private final Integer studentCount;
+
+    private final CourseStatus status;
+
+    private final Long revenue;
+}

--- a/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/InstructorStatisticsResDto.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/InstructorStatisticsResDto.java
@@ -1,0 +1,32 @@
+package com.example.sesacrunback.domain.course.course.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강사 통계 정보 응답 DTO
+ * - 강사 대시보드에서 사용
+ * - 총 강의 수, 총 수강생 수, 총 수익 정보 제공
+ */
+@Getter
+@RequiredArgsConstructor
+public class InstructorStatisticsResDto {
+
+    private final Integer totalCourses;
+
+    private final Integer totalStudents;
+
+    private final Long totalRevenue;
+
+    public static InstructorStatisticsResDto of(
+            Integer totalCourses,
+            Integer totalStudents,
+            Long totalRevenue
+    ) {
+        return new InstructorStatisticsResDto(
+                totalCourses,
+                totalStudents,
+                totalRevenue
+        );
+    }
+}

--- a/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/InstructorStatisticsResDto.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/dto/response/InstructorStatisticsResDto.java
@@ -14,13 +14,13 @@ public class InstructorStatisticsResDto {
 
     private final Integer totalCourses;
 
-    private final Integer totalStudents;
+    private final Long totalStudents;
 
     private final Long totalRevenue;
 
     public static InstructorStatisticsResDto of(
             Integer totalCourses,
-            Integer totalStudents,
+            Long totalStudents,
             Long totalRevenue
     ) {
         return new InstructorStatisticsResDto(

--- a/src/main/java/com/example/sesacrunback/domain/course/course/entity/Course.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/entity/Course.java
@@ -44,8 +44,25 @@ public class Course extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer price;
 
+    /**
+     * 수강생 수 캐시 값
+     * - ACTIVE Enrollment 수를 기준으로 계산된 결과
+     * - Enrollment COUNT 쿼리 비용을 줄이기 위한 캐시 필드
+     * - 최종 권위 데이터는 Enrollment (정확한 수치는 Enrollment 테이블 조회)
+     * - 조회/정렬/통계 목적으로 사용
+     * - Eventual Consistency: 트랜잭션 커밋 전까지 실제 Enrollment 수와 일시적 차이가 발생할 수 있음
+     */
     @Column(nullable = false)
     private Integer studentCount = 0;
+
+    /**
+     * Optimistic Lock을 위한 버전 필드
+     * - 동시성 제어: 동시에 여러 결제/환불이 발생해도 studentCount 일관성 유지
+     * - OptimisticLockException 발생 시 트랜잭션 롤백
+     * - JPA가 자동으로 관리 (초기값 0, 수정 시 자동 증가)
+     */
+    @Version
+    private Long version;
 
     @ElementCollection
     @CollectionTable(
@@ -166,8 +183,23 @@ public class Course extends BaseTimeEntity {
 
     /* ================= 비즈니스 로직 ================= */
 
-    public void incrementStudentCount() {
+    /**
+     * 수강생 수 증가
+     * - Enrollment가 ACTIVE로 새로 생성될 때만 호출
+     */
+    public void increaseStudentCount() {
         this.studentCount++;
+    }
+
+    /**
+     * 수강생 수 감소
+     * - Enrollment.status가 ACTIVE → CANCELED로 전이될 때만 호출
+     * - 0 미만으로 내려가지 않도록 방어
+     */
+    public void decreaseStudentCount() {
+        if (this.studentCount > 0) {
+            this.studentCount--;
+        }
     }
 
     /* ================= 편의 메서드 ================= */

--- a/src/main/java/com/example/sesacrunback/domain/course/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/repository/CourseRepository.java
@@ -1,5 +1,6 @@
 package com.example.sesacrunback.domain.course.course.repository;
 
+import com.example.sesacrunback.domain.course.course.dto.response.InstructorCourseRevenueDto;
 import com.example.sesacrunback.domain.course.course.entity.Course;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -86,6 +87,53 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     """)
     Page<Course> searchCourses(
             @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /* ===============================
+     * 통계 (강사 대시보드용)
+     * =============================== */
+
+    /**
+     * 강사별 강의 수
+     */
+    Long countByInstructor_Id(Long instructorId);
+
+    /**
+     * 강사별 총 수강생 수 (studentCount 합산)
+     * - Course.studentCount는 ACTIVE Enrollment 수를 캐싱한 값
+     * - 정확한 실시간 수치는 Enrollment COUNT 쿼리로 확인 가능
+     */
+    @Query("SELECT COALESCE(SUM(c.studentCount), 0) FROM Course c WHERE c.instructor.id = :instructorId")
+    Integer sumStudentCountByInstructor_Id(@Param("instructorId") Long instructorId);
+
+    /**
+     * 강사 대시보드 - 운영 중인 강의 목록 (수익 포함)
+     * - DTO Projection으로 한 번의 쿼리로 Course + Revenue 조회
+     * - Payment.amount 기준 수익 계산 (결제 금액의 단일 권위)
+     * - Payment.status = 'COMPLETED'만 집계
+     * - 무료 강의(price = 0)는 revenue = 0
+     */
+    @Query("""
+        SELECT new com.example.sesacrunback.domain.course.course.dto.response.InstructorCourseRevenueDto(
+            c.id,
+            c.title,
+            c.thumbnail,
+            c.price,
+            c.studentCount,
+            c.status,
+            COALESCE(SUM(p.amount), 0)
+        )
+        FROM Course c
+        LEFT JOIN OrderItem oi ON oi.course = c
+        LEFT JOIN Order o ON oi.order = o
+        LEFT JOIN Payment p ON p.order = o AND p.status = 'COMPLETED'
+        WHERE c.instructor.id = :instructorId
+        GROUP BY c.id, c.title, c.thumbnail, c.price, c.studentCount, c.status
+        ORDER BY c.createdAt DESC
+    """)
+    Page<InstructorCourseRevenueDto> findInstructorCoursesWithRevenue(
+            @Param("instructorId") Long instructorId,
             Pageable pageable
     );
 }

--- a/src/main/java/com/example/sesacrunback/domain/course/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/repository/CourseRepository.java
@@ -103,16 +103,18 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
      * 강사별 총 수강생 수 (studentCount 합산)
      * - Course.studentCount는 ACTIVE Enrollment 수를 캐싱한 값
      * - 정확한 실시간 수치는 Enrollment COUNT 쿼리로 확인 가능
+     * - JPQL SUM은 Long 반환 (Integer 필드도 Long 반환)
      */
     @Query("SELECT COALESCE(SUM(c.studentCount), 0) FROM Course c WHERE c.instructor.id = :instructorId")
-    Integer sumStudentCountByInstructor_Id(@Param("instructorId") Long instructorId);
+    Long sumStudentCountByInstructor_Id(@Param("instructorId") Long instructorId);
 
     /**
      * 강사 대시보드 - 운영 중인 강의 목록 (수익 포함)
      * - DTO Projection으로 한 번의 쿼리로 Course + Revenue 조회
-     * - Payment.amount 기준 수익 계산 (결제 금액의 단일 권위)
-     * - Payment.status = 'COMPLETED'만 집계
-     * - 무료 강의(price = 0)는 revenue = 0
+     * - OrderItem.price 기준 수익 계산 (강의별 실제 판매 가격)
+     * - Order.status = 'COMPLETED'만 집계
+     * - 스칼라 서브쿼리로 강의별 수익 정확히 계산 (중복 집계 방지)
+     * - 정렬은 Pageable로 동적 처리
      */
     @Query("""
         SELECT new com.example.sesacrunback.domain.course.course.dto.response.InstructorCourseRevenueDto(
@@ -122,15 +124,13 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             c.price,
             c.studentCount,
             c.status,
-            COALESCE(SUM(p.amount), 0)
+            (SELECT COALESCE(SUM(oi.price), 0)
+             FROM OrderItem oi
+             JOIN oi.order o
+             WHERE oi.course = c AND o.status = 'COMPLETED')
         )
         FROM Course c
-        LEFT JOIN OrderItem oi ON oi.course = c
-        LEFT JOIN Order o ON oi.order = o
-        LEFT JOIN Payment p ON p.order = o AND p.status = 'COMPLETED'
         WHERE c.instructor.id = :instructorId
-        GROUP BY c.id, c.title, c.thumbnail, c.price, c.studentCount, c.status
-        ORDER BY c.createdAt DESC
     """)
     Page<InstructorCourseRevenueDto> findInstructorCoursesWithRevenue(
             @Param("instructorId") Long instructorId,

--- a/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
@@ -165,8 +165,8 @@ public class CourseService {
         // 1. 총 강의 수
         int totalCourses = courseRepository.countByInstructor_Id(instructorId).intValue();
 
-        // 2. 총 수강생 수 (studentCount 합산)
-        Integer totalStudents = courseRepository.sumStudentCountByInstructor_Id(instructorId);
+        // 2. 총 수강생 수 (studentCount 합산) - JPQL SUM은 Long 반환
+        Long totalStudents = courseRepository.sumStudentCountByInstructor_Id(instructorId);
 
         // 3. 총 수익 (Phase 1에서 만든 쿼리 사용)
         Long totalRevenue = paymentRepository.calculateTotalRevenueByInstructor(instructorId);

--- a/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
+++ b/src/main/java/com/example/sesacrunback/domain/course/course/service/CourseService.java
@@ -7,11 +7,14 @@ import com.example.sesacrunback.domain.course.course.dto.response.CourseResponse
 import com.example.sesacrunback.domain.course.course.dto.response.CourseViewContext;
 import com.example.sesacrunback.domain.course.course.dto.response.CourseWatchResponse;
 import com.example.sesacrunback.domain.course.course.dto.response.EnrolledCourseResponse;
+import com.example.sesacrunback.domain.course.course.dto.response.InstructorCourseRevenueDto;
+import com.example.sesacrunback.domain.course.course.dto.response.InstructorStatisticsResDto;
 import com.example.sesacrunback.domain.course.course.entity.Course;
 import com.example.sesacrunback.domain.course.course.repository.CourseRepository;
 import com.example.sesacrunback.domain.enrollment.entity.EnrollmentStatus;
 import com.example.sesacrunback.domain.enrollment.repository.EnrollmentRepository;
 import com.example.sesacrunback.domain.course.lecture.entity.Lecture;
+import com.example.sesacrunback.domain.payment.repository.PaymentRepository;
 import com.example.sesacrunback.domain.user.entity.User;
 import com.example.sesacrunback.global.exception.CustomException;
 import com.example.sesacrunback.global.exception.ErrorCode;
@@ -37,6 +40,7 @@ public class CourseService {
     private final CourseRepository courseRepository;
     private final EntityManager entityManager;
     private final EnrollmentRepository enrollmentRepository;
+    private final PaymentRepository paymentRepository;
 
     /**
      * 강의 생성 (Phase 1: 생성 즉시 게시)
@@ -141,12 +145,33 @@ public class CourseService {
 
     /**
      * 강사의 강의 목록 조회 (페이징)
+     * - 강의별 수익 포함 (Payment.amount 기준)
      */
-    public Page<CourseResponse> getMyCourses(Pageable pageable, Long instructorId) {
+    public Page<InstructorCourseRevenueDto> getMyCourses(Pageable pageable, Long instructorId) {
         log.info("Getting courses for instructor ID: {}", instructorId);
 
-        return courseRepository.findByInstructor_Id(instructorId, pageable)
-                .map(CourseResponse::from);
+        return courseRepository.findInstructorCoursesWithRevenue(instructorId, pageable);
+    }
+
+    /**
+     * 강사 통계 조회 (대시보드용)
+     * - 총 강의 수
+     * - 총 수강생 수 (Course.studentCount 합산)
+     * - 총 수익 (COMPLETED 주문 기준)
+     */
+    public InstructorStatisticsResDto getMyStatistics(Long instructorId) {
+        log.info("Getting statistics for instructor ID: {}", instructorId);
+
+        // 1. 총 강의 수
+        int totalCourses = courseRepository.countByInstructor_Id(instructorId).intValue();
+
+        // 2. 총 수강생 수 (studentCount 합산)
+        Integer totalStudents = courseRepository.sumStudentCountByInstructor_Id(instructorId);
+
+        // 3. 총 수익 (Phase 1에서 만든 쿼리 사용)
+        Long totalRevenue = paymentRepository.calculateTotalRevenueByInstructor(instructorId);
+
+        return InstructorStatisticsResDto.of(totalCourses, totalStudents, totalRevenue);
     }
 
     /**

--- a/src/main/java/com/example/sesacrunback/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/example/sesacrunback/domain/enrollment/service/EnrollmentService.java
@@ -22,6 +22,9 @@ public class EnrollmentService {
 
     /**
      * Order 결제 완료 시 Enrollment 생성
+     * - Enrollment 생성과 studentCount 증가는 같은 트랜잭션 내에서 원자적으로 처리됨
+     * - 트랜잭션 롤백 시 Enrollment 생성과 studentCount 증가가 함께 취소됨
+     * - 향후 비동기/이벤트 기반으로 변경 시 분리 고려 필요
      */
     @Transactional
     public void createForOrder(Order order, User user) {
@@ -39,6 +42,8 @@ public class EnrollmentService {
             if (!enrollmentRepository.existsByUserIdAndCourseIdAndStatus(
                     user.getId(), course.getId(), EnrollmentStatus.ACTIVE)) {
                 enrollmentRepository.save(Enrollment.forOrder(user, course, order));
+                // ACTIVE Enrollment 생성 시 studentCount 증가
+                course.increaseStudentCount();
             }
 
             processedCourseIds.add(course.getId());
@@ -47,6 +52,9 @@ public class EnrollmentService {
 
     /**
      * 환불 시 Enrollment 취소
+     * - ACTIVE 상태만 찾아 처리하므로 멱등성 보장
+     * - 중복 호출 시에도 안전 (예외 발생 없음)
+     * - Enrollment 취소와 studentCount 감소는 같은 트랜잭션 내에서 원자적으로 처리됨
      */
     @Transactional
     public void cancelForOrder(Order order, User user) {
@@ -66,7 +74,10 @@ public class EnrollmentService {
                             course.getId(),
                             EnrollmentStatus.ACTIVE
                     )
-                    .ifPresent(Enrollment::cancel);
+                    .ifPresent(enrollment -> {
+                        enrollment.cancel();  // ACTIVE → CANCELED
+                        course.decreaseStudentCount();
+                    });
 
             processedCourseIds.add(course.getId());
         }

--- a/src/main/java/com/example/sesacrunback/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/sesacrunback/domain/payment/repository/PaymentRepository.java
@@ -2,7 +2,40 @@ package com.example.sesacrunback.domain.payment.repository;
 
 import com.example.sesacrunback.domain.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     boolean existsByPortonePaymentId(String impUid);
+
+    /**
+     * 강의별 총 수익 계산
+     * - OrderItem.price 기준 (주문 당시 가격)
+     * - Order.status = COMPLETED 인 주문만 집계
+     * - 환불된 주문은 자동 제외됨
+     */
+    @Query("""
+        SELECT COALESCE(SUM(oi.price), 0)
+        FROM Order o
+        JOIN o.orderItems oi
+        WHERE oi.course.id = :courseId
+          AND o.status = 'COMPLETED'
+    """)
+    Long calculateTotalRevenueByCourse(@Param("courseId") Long courseId);
+
+    /**
+     * 강사별 총 수익 계산
+     * - OrderItem.price 기준 (주문 당시 가격)
+     * - Order.status = COMPLETED 인 주문만 집계
+     * - 환불된 주문은 자동 제외됨
+     */
+    @Query("""
+        SELECT COALESCE(SUM(oi.price), 0)
+        FROM Order o
+        JOIN o.orderItems oi
+        JOIN oi.course c
+        WHERE c.instructor.id = :instructorId
+          AND o.status = 'COMPLETED'
+    """)
+    Long calculateTotalRevenueByInstructor(@Param("instructorId") Long instructorId);
 }

--- a/src/main/java/com/example/sesacrunback/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/sesacrunback/domain/payment/service/PaymentService.java
@@ -20,7 +20,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import com.example.sesacrunback.domain.orderItem.entity.OrderItem;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/sesacrunback/domain/refund/service/RefundService.java
+++ b/src/main/java/com/example/sesacrunback/domain/refund/service/RefundService.java
@@ -12,6 +12,7 @@ import com.example.sesacrunback.domain.refund.entity.RefundStatus;
 import com.example.sesacrunback.domain.refund.repository.RefundRepository;
 import com.example.sesacrunback.domain.user.entity.User;
 import com.example.sesacrunback.domain.user.repository.UserRepository;
+import com.example.sesacrunback.domain.enrollment.service.EnrollmentService;
 import com.example.sesacrunback.global.exception.CustomException;
 import com.example.sesacrunback.global.exception.ErrorCode;
 import com.siot.IamportRestClient.IamportClient;
@@ -31,6 +32,7 @@ public class RefundService {
     private final UserRepository userRepository;
     private final OrderRepository orderRepository;
     private final RefundRepository refundRepository;
+    private final EnrollmentService enrollmentService;
     private final IamportClient iamportClient;
 
     public RefundResponse createRefund(RefundRequest request, Long userId) {
@@ -67,6 +69,7 @@ public class RefundService {
             if (payment.getAmount() == 0) {
                 order.cancel();
                 payment.cancel();
+                enrollmentService.cancelForOrder(order, user);
                 refund.complete();
                 return RefundResponse.builder()
                         .refundId(refund.getId())
@@ -87,6 +90,7 @@ public class RefundService {
             // 성공 시 DB 상태 변경
             order.cancel();
             payment.cancel();
+            enrollmentService.cancelForOrder(order, user);
             refund.complete();
 
             return RefundResponse.builder()

--- a/src/main/java/com/example/sesacrunback/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sesacrunback/global/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers("/ws-stomp/**").permitAll()  // WebSocket 엔드포인트 허용
 
                         // 강의
+                        .requestMatchers(HttpMethod.GET, "/api/courses/my/statistics").hasRole("INSTRUCTOR") // 통계 조회: 강사
                         .requestMatchers(HttpMethod.GET, "/api/courses/my").hasRole("INSTRUCTOR") // 조회: 강사
                         .requestMatchers(HttpMethod.POST,"/api/courses").hasRole("INSTRUCTOR") // 작성: 강사
                         .requestMatchers(HttpMethod.DELETE,"/api/courses/**").hasRole("INSTRUCTOR") // 삭제: 강사

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,7 +2,9 @@
 INSERT INTO users (email, password, name, role, created_at, updated_at) VALUES
 ('instructor@test.com', '$2a$10$BWu6umBCNEsCR7705J1LH.oiJfFB9XQK3wUMvW5eGiX9b0gx/CcyG', '김강사', 'INSTRUCTOR', NOW(), NOW()),
 ('user1@test.com', '$2a$10$BWu6umBCNEsCR7705J1LH.oiJfFB9XQK3wUMvW5eGiX9b0gx/CcyG', '이학생', 'USER', NOW(), NOW()),
-('user2@test.com', '$2a$10$BWu6umBCNEsCR7705J1LH.oiJfFB9XQK3wUMvW5eGiX9b0gx/CcyG', '박학생', 'USER', NOW(), NOW());
+('user2@test.com', '$2a$10$BWu6umBCNEsCR7705J1LH.oiJfFB9XQK3wUMvW5eGiX9b0gx/CcyG', '박학생', 'USER', NOW(), NOW()),
+('user3@test.com', '$2a$10$BWu6umBCNEsCR7705J1LH.oiJfFB9XQK3wUMvW5eGiX9b0gx/CcyG', '최학생', 'USER', NOW(), NOW()),
+('user4@test.com', '$2a$10$BWu6umBCNEsCR7705J1LH.oiJfFB9XQK3wUMvW5eGiX9b0gx/CcyG', '정학생', 'USER', NOW(), NOW());
 
 -- Courses
 INSERT INTO courses (title, description, detailed_description, thumbnail, category, price, student_count, status, instructor_id, created_at, updated_at) VALUES
@@ -121,3 +123,82 @@ INSERT INTO enrollments (
              NOW(),
              NOW()
          );
+
+-- ========================================
+-- 추가 테스트 데이터 (총 수강생 수 & 수익 검증용)
+-- ========================================
+
+-- [강의 1: 자바 완전 정복 - 무료 강의]
+-- 박학생(user_id=3)이 무료 강의 수강
+INSERT INTO orders (order_number, total_amount, status, user_id, created_at, updated_at)
+VALUES ('ORD-20231223-0001', 0, 'COMPLETED', 3, NOW(), NOW());
+
+INSERT INTO order_items (course_name, price, order_id, course_id, created_at)
+VALUES ('자바 완전 정복', 0, LAST_INSERT_ID(), 1, NOW());
+
+INSERT INTO payments (portone_payment_id, amount, status, order_id, created_at, updated_at)
+VALUES ('imp_free_001', 0, 'COMPLETED', LAST_INSERT_ID(), NOW(), NOW());
+
+INSERT INTO enrollments (user_id, course_id, order_id, status, created_at, updated_at)
+VALUES (3, 1, LAST_INSERT_ID(), 'ACTIVE', NOW(), NOW());
+
+-- [강의 2: 스프링 부트 입문 - 유료 강의]
+-- 박학생(user_id=3)이 유료 강의 구매 (1000원)
+INSERT INTO orders (order_number, total_amount, status, user_id, created_at, updated_at)
+VALUES ('ORD-20231223-0002', 1000, 'COMPLETED', 3, NOW(), NOW());
+
+INSERT INTO order_items (course_name, price, order_id, course_id, created_at)
+VALUES ('스프링 부트 입문', 1000, LAST_INSERT_ID(), 2, NOW());
+
+INSERT INTO payments (portone_payment_id, amount, status, order_id, created_at, updated_at)
+VALUES ('imp_paid_001', 1000, 'COMPLETED', LAST_INSERT_ID(), NOW(), NOW());
+
+INSERT INTO enrollments (user_id, course_id, order_id, status, created_at, updated_at)
+VALUES (3, 2, LAST_INSERT_ID(), 'ACTIVE', NOW(), NOW());
+
+-- 최학생(user_id=4)이 유료 강의 구매 (1000원)
+INSERT INTO orders (order_number, total_amount, status, user_id, created_at, updated_at)
+VALUES ('ORD-20231223-0003', 1000, 'COMPLETED', 4, NOW(), NOW());
+
+INSERT INTO order_items (course_name, price, order_id, course_id, created_at)
+VALUES ('스프링 부트 입문', 1000, LAST_INSERT_ID(), 2, NOW());
+
+INSERT INTO payments (portone_payment_id, amount, status, order_id, created_at, updated_at)
+VALUES ('imp_paid_002', 1000, 'COMPLETED', LAST_INSERT_ID(), NOW(), NOW());
+
+INSERT INTO enrollments (user_id, course_id, order_id, status, created_at, updated_at)
+VALUES (4, 2, LAST_INSERT_ID(), 'ACTIVE', NOW(), NOW());
+
+-- 정학생(user_id=5)이 유료 강의 구매 후 환불 (CANCELED)
+INSERT INTO orders (order_number, total_amount, status, user_id, created_at, updated_at)
+VALUES ('ORD-20231223-0004', 1000, 'COMPLETED', 5, NOW(), NOW());
+
+INSERT INTO order_items (course_name, price, order_id, course_id, created_at)
+VALUES ('스프링 부트 입문', 1000, LAST_INSERT_ID(), 2, NOW());
+
+-- 결제는 완료되었지만 환불됨 (REFUND)
+INSERT INTO payments (portone_payment_id, amount, status, order_id, created_at, updated_at)
+VALUES ('imp_refund_001', 1000, 'REFUND', LAST_INSERT_ID(), NOW(), NOW());
+
+-- Enrollment도 CANCELED
+INSERT INTO enrollments (user_id, course_id, order_id, status, created_at, updated_at)
+VALUES (5, 2, LAST_INSERT_ID(), 'CANCELED', NOW(), NOW());
+
+-- ========================================
+-- Course studentCount 업데이트
+-- ========================================
+-- 강의 1: ACTIVE Enrollment 2개 (user_id=2, 3)
+UPDATE courses SET student_count = 2 WHERE id = 1;
+
+-- 강의 2: ACTIVE Enrollment 2개 (user_id=3, 4), CANCELED 1개 (user_id=5는 카운트 안됨)
+UPDATE courses SET student_count = 2 WHERE id = 2;
+
+-- ========================================
+-- 검증 요약
+-- ========================================
+-- 강사(instructor_id=1) 통계:
+-- - 총 강의 수: 2개
+-- - 총 수강생 수: 4명 (강의1: 2명, 강의2: 2명)
+-- - 총 수익: 2000원 (강의1: 0원, 강의2: 2000원)
+--   * Payment.status='COMPLETED'만 집계
+--   * 환불된 건(REFUND)은 수익에서 제외됨


### PR DESCRIPTION
## ✨ 변경 사항
- 환불 할 시에 enrollment의 status가 변경 될 수 있도록 수정
- data.sql 수정 
- 운영중인 강의 dto 수정 
- 강사 총 수익을 알 수 있는 api 하나 새로 생성

## 🔍 관련 이슈

- studentCount를 셀 때 동시성 이슈가 있어 @version을 사용

## 📌 작업 내용

- [V] 기능 구현
- [ ] 테스트 작성
- [V] 리팩토링

## 🧪 테스트 방법

## 📎 기타 참고사항